### PR TITLE
feat!: refactor error handling and add option pattern for DTO processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,25 @@ A lightweight Go package providing HTTP request/response utilities with:
 - Form data parsing
 - Data validation
 - DTO pattern implementation
-- Consistent error handling
+- Structured error handling with option pattern
+- Customizable error handlers
+- Validation middleware support
 
 ## Features
 
-### Request Context
+### Request Processing Pipeline
 ```go
-r := httputil.Context(req, w) // Create request context
-```
+// Create context and handle request
+r := httputil.Context(req, w)
 
-### JSON Handling
-```go
-// Decode request body
-err := r.Decode(&myStruct)
+// Decode, validate and convert to domain model
+model, ok := httputil.DecodeAndValidateRequest(r, &requestDTO)
+if !ok {
+    return // Error already handled
+}
 
-// Encode response
-r.Encode(responseData)
+// Encode response from domain model
+_ = httputil.EncodeResponse(r, model, &responseDTO)
 ```
 
 ### Form Data Parsing
@@ -40,13 +43,20 @@ err := r.Validate(validator)
 errors, err := r.ValidateRequest(validator)
 ```
 
-### DTO Pattern
+### Option Pattern Configuration
 ```go
-// Request processing pipeline
-err := r.DecodeAndValidateRequest(dto, &model)
+// Custom error handler that logs errors
+errorHandler := func(ctx httputil.RequestContext, err error) {
+    log.Printf("Request error: %v", err)
+    httputil.DefaultErrorHandler{}.HandleError(ctx, err)
+}
 
-// Response pipeline  
-r.EncodeResponse(model, dto)
+// Use custom handler for a request
+model, ok := httputil.DecodeAndValidateRequest(
+    r, 
+    &requestDTO,
+    httputil.WithErrorHandler(errorHandler),
+)
 ```
 
 ## Installation
@@ -54,92 +64,102 @@ r.EncodeResponse(model, dto)
 go get go.lumeweb.com/httputil
 ```
 
-## Examples
+## Error Handling
 
-### Basic Handler
+The package provides three levels of error handling:
+
+1. **Automatic Errors** (400/422/500 status codes):
 ```go
-func handler(w http.ResponseWriter, req *http.Request) {
-    r := httputil.Context(req, w)
-    
-    var input InputDTO
-    if err := r.DecodeAndValidateRequest(&input, &model); err != nil {
-        return // Error already handled
-    }
-    
-    // Process model...
-    
-    r.EncodeResponse(model, &OutputDTO{})
-}
+// Errors automatically handled with appropriate status codes
+model, ok := httputil.DecodeAndValidateRequest(r, &dto)
 ```
 
-### Complete Example with Structs
-
-#### Request DTO Example
+2. **Custom Error Handler**:
 ```go
-type CreateUserRequest struct {
-    Username string `json:"username"`
-    Email    string `json:"email"`
-    Age      int    `json:"age"`
+// Create custom error handler
+type LoggingHandler struct{}
+
+func (h LoggingHandler) HandleError(ctx httputil.RequestContext, err error) {
+    log.Printf("Error processing request: %v", err)
+    httputil.DefaultErrorHandler{}.HandleError(ctx, err)
 }
 
-func (r *CreateUserRequest) ToModel(model any) error {
-    user, ok := model.(*User) // Assume User is your domain model
-    if !ok {
-        return fmt.Errorf("expected *User, got %T", model)
-    }
-    user.Username = r.Username
-    user.Email = r.Email
-    user.Age = r.Age
-    return nil
-}
-
-func (r *CreateUserRequest) Schema() *z.StructSchema {
-    return z.Struct(z.Schema{
-        "username": z.String().Min(3).Max(50),
-        "email":    z.String().Email(),
-        "age":      z.Number().Min(18).Max(120),
-    })
-}
+// Use custom handler
+model, ok := httputil.DecodeAndValidateRequest(
+    r,
+    &dto,
+    httputil.WithErrorHandler(LoggingHandler{}),
+)
 ```
 
-#### Response DTO Example
+3. **Manual Error Handling**:
 ```go
-type UserResponse struct {
-    ID       string `json:"id"`
-    Username string `json:"username"`
-    Email    string `json:"email"`
+// Full manual control
+cfg := httputil.vdConfig{
+    errorHandler: httputil.ErrorHandlerFunc(func(ctx httputil.RequestContext, err error) {
+        // Custom error handling logic
+    }),
 }
 
-func (r *UserResponse) FromModel(model any) error {
-    user, ok := model.(*User)
-    if !ok {
-        return fmt.Errorf("expected *User, got %T", model)
-    }
-    r.ID = user.ID
-    r.Username = user.Username
-    r.Email = user.Email
-    return nil
-}
+model, ok := httputil.DecodeAndValidateRequest(r, &dto, httputil.WithErrorHandler(cfg.errorHandler))
 ```
 
-#### Full Handler Example
+### Complete Example
+
+#### Request/Response Flow
 ```go
 func createUserHandler(w http.ResponseWriter, req *http.Request) {
+    // Initialize context
     r := httputil.Context(req, w)
     
-    var input CreateUserRequest
-    var user User
+    // Decode and validate request
+    var createReq CreateUserRequest
+    user, ok := httputil.DecodeAndValidateRequest(r, &createReq)
+    if !ok {
+        return // Error response already handled
+    }
     
-    if err := r.DecodeAndValidateRequest(&input, &user); err != nil {
-        // Error already handled with proper HTTP response
+    // Business logic
+    if err := userService.Create(user); err != nil {
+        _ = r.Error(fmt.Errorf("creation failed: %w", err), http.StatusConflict)
         return
     }
     
-    // Save user to database...
-    user.ID = generateID()
+    // Create and send response
+    resp := UserResponse{}
+    _ = httputil.EncodeResponse(r, user, &resp)
+}
+```
+
+#### Custom Error Handling
+```go
+type MetricsErrorHandler struct {
+    metricsClient metrics.Client
+}
+
+func (h MetricsErrorHandler) HandleError(ctx httputil.RequestContext, err error) {
+    // Track error metrics
+    h.metricsClient.Increment("request.errors", 1)
     
-    // Return response
-    r.EncodeResponse(&user, &UserResponse{})
+    // Fallback to default handling
+    httputil.DefaultErrorHandler{}.HandleError(ctx, err)
+}
+
+// Usage
+func metricsMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        ctx := httputil.Context(r, w)
+        handler := MetricsErrorHandler{metricsClient: globalMetrics}
+        
+        // Process request with metrics tracking
+        var createReq CreateUserRequest
+        user, ok := httputil.DecodeAndValidateRequest(
+            ctx, 
+            &createReq,
+            httputil.WithErrorHandler(handler),
+        )
+        // ... rest of handler logic
+    })
 }
 ```
 

--- a/context.go
+++ b/context.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 )
 
-// RequestContext carries HTTP request-scoped values and provides utility methods.
-// It wraps:
-// - Standard context.Context
-// - HTTP request object
-// - HTTP response writer
+// RequestContext carries HTTP request-scoped values and provides utility methods
+// for handling the complete request/response lifecycle. It combines:
+// - Standard context.Context for cancellation and deadlines
+// - HTTP request object for reading request data
+// - HTTP response writer for sending responses
+// - Validation and encoding utilities
 type RequestContext struct {
 	context.Context
 	Request  *http.Request

--- a/doc.go
+++ b/doc.go
@@ -1,10 +1,17 @@
-// Package httputil provides HTTP utility functions and middleware for building web applications.
-// It includes features for request/response handling, data validation, DTO mapping, and error handling.
+// Package httputil provides HTTP utility functions for building robust web APIs in Go.
+// It implements patterns for type-safe request/response handling with validation and structured error reporting.
 //
-// The package focuses on:
-// - Streamlined request context management
-// - JSON encoding/decoding with proper error handling
-// - Data validation using struct schemas
-// - DTO pattern implementation
-// - Consistent error responses
+// Key features:
+// - DTO (Data Transfer Object) pattern for request/response marshaling
+// - Declarative validation using struct schemas
+// - Option pattern configuration for request processing
+// - Automatic error classification and JSON error responses
+// - Context-aware request handling
+//
+// The package emphasizes:
+// - Type safety through generics
+// - Clear separation of concerns
+// - Customizable error handling
+// - Consistent JSON formatting
+// - Middleware-ready components
 package httputil

--- a/dto.go
+++ b/dto.go
@@ -1,46 +1,127 @@
 package httputil
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 )
 
-// DTORequest defines the interface for Data Transfer Objects (DTOs) that convert
-// incoming requests to domain models. Implementations should handle validation
-// and conversion logic.
+// DTORequest defines the interface for request Data Transfer Objects that convert
+// HTTP requests to domain models. Implementations should:
+// - Handle validation through the DTOValidator interface (optional)
+// - Convert the raw request to a domain model
+// - Return clean domain objects or validation errors
 type DTORequest[M any] interface {
 	ToModel() (M, error) // Returns a new model of type M
 }
 
-// DTOResponse defines the interface for DTOs that convert domain models to
-// API responses. Implementations should handle serialization and formatting.
+// DTOResponse defines the interface for response Data Transfer Objects that convert
+// domain models to HTTP responses. Implementations should:
+// - Format domain objects for JSON serialization
+// - Maintain stable API contracts
+// - Handle serialization-specific logic
 type DTOResponse[M any] interface {
 	FromModel(model M) error // Takes a model of type M
 }
 
-// DecodeAndValidateRequest handles the complete request processing pipeline.
-// It uses generics to ensure type safety when decoding and validating
-func DecodeAndValidateRequest[M any, D DTORequest[M]](r RequestContext, dto D) (M, error) {
-	var zero M
+// ErrorHandler defines the strategy pattern for error handling during request processing.
+// Implementations can customize error logging, formatting, and status code selection.
+type ErrorHandler interface {
+	HandleError(ctx RequestContext, err error)
+}
 
-	if err := r.Decode(dto); err != nil {
-		return zero, err
+// DefaultErrorHandler provides standardized error handling with:
+// - 400 Bad Request for JSON syntax/type errors
+// - 422 Unprocessable Entity for validation errors
+// - 500 Internal Server Error for all other cases
+type DefaultErrorHandler struct{}
+
+// HandleError implements ErrorHandler with status code detection
+func (h *DefaultErrorHandler) HandleError(ctx RequestContext, err error) {
+	var status = http.StatusInternalServerError
+
+	var jsonTypeErr *json.UnmarshalTypeError
+	var jsonSyntaxErr *json.SyntaxError
+
+	switch {
+	case IsValidationError(err):
+		status = http.StatusUnprocessableEntity
+	case errors.As(err, &jsonTypeErr),
+		errors.As(err, &jsonSyntaxErr):
+		status = http.StatusBadRequest
 	}
 
-	// Check if the DTO implements DTOValidator and, if so, validate it.
+	_ = ctx.Error(err, status)
+}
+
+// VDOption configures DecodeAndValidateRequest processing behavior using the option pattern.
+// These allow customizing validation handling per API endpoint while maintaining a consistent interface.
+type VDOption func(*vdConfig)
+
+type vdConfig struct {
+	errorHandler ErrorHandler
+}
+
+// WithErrorHandler specifies a custom error handler for request processing.
+// This option allows overriding the default error response strategy while
+// maintaining the standard validation and decoding pipeline.
+func WithErrorHandler(h ErrorHandler) VDOption {
+	return func(c *vdConfig) {
+		c.errorHandler = h
+	}
+}
+
+// DecodeAndValidateRequest handles the complete request processing pipeline:
+//  1. Decode request body to DTO
+//  2. Validate using DTOValidator interface (if implemented)
+//  3. Convert to domain model using ToModel()
+//
+// Returns:
+//   - The parsed domain model and true on success
+//   - Zero value and false on any error, with error handling delegated to the ErrorHandler
+//
+// The function uses generics to ensure type safety and accepts optional VDOptions
+// to customize processing behavior per invocation.
+func DecodeAndValidateRequest[M any, D DTORequest[M]](
+	r RequestContext,
+	dto D,
+	opts ...VDOption,
+) (M, bool) {
+	var zero M
+
+	// Configure defaults
+	cfg := &vdConfig{
+		errorHandler: &DefaultErrorHandler{},
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Decode phase
+	if err := r.Decode(dto); err != nil {
+		cfg.errorHandler.HandleError(r, err)
+		return zero, false
+	}
+
+	// Validation phase
 	if validator, ok := any(dto).(DTOValidator); ok {
 		if verr := r.Validate(validator); verr != nil {
-			// Handle validation errors with structured response
-			var vErr *ValidationError
-			if errors.As(verr, &vErr) {
-				return zero, r.Error(vErr, http.StatusUnprocessableEntity)
-			}
-			return zero, verr
+			cfg.errorHandler.HandleError(r, verr)
+			return zero, false
 		}
 	}
 
-	return dto.ToModel()
+	// Model conversion
+	model, err := dto.ToModel()
+	if err != nil {
+		cfg.errorHandler.HandleError(r, err)
+		return zero, false
+	}
+
+	return model, true
 }
 
 // EncodeResponse handles the response generation pipeline.

--- a/dto_test.go
+++ b/dto_test.go
@@ -32,9 +32,9 @@ func TestDecodeAndValidateRequest(t *testing.T) {
 	dto.EXPECT().ToModel().Return(model, nil)
 
 	// Call the function with the new validator that has the schema setup
-	modelResult, err := DecodeAndValidateRequest(r, dto)
-	if err != nil {
-		t.Fatalf("DecodeAndValidateRequest failed: %v", err)
+	modelResult, ok := DecodeAndValidateRequest(r, dto)
+	if !ok {
+		t.Fatal("DecodeAndValidateRequest failed")
 	}
 
 	// Verify that the model was updated correctly
@@ -97,16 +97,23 @@ func TestDecodeAndValidateRequest_DecodeError(t *testing.T) {
 	dto := mocks.NewMockDTORequest[*testDTO](t)
 
 	// Call the function - should fail at decode step
-	_, err := DecodeAndValidateRequest(r, dto)
-
-	if err == nil {
-		t.Fatal("DecodeAndValidateRequest should have returned a decoding error")
+	_, ok := DecodeAndValidateRequest(r, dto)
+	if ok {
+		t.Fatal("DecodeAndValidateRequest should have failed")
 	}
 
-	// Verify we got the JSON unmarshal error
-	expectedErrorMessage := "cannot unmarshal number into Go struct field"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		t.Errorf("Error message mismatch:\ngot: %v\nwant: %v", err.Error(), expectedErrorMessage)
+	// Verify response status and error format
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if !strings.Contains(resp["error"].(string), "cannot unmarshal number into Go struct field") {
+		t.Errorf("Error message mismatch:\ngot: %v\nwant: %v", resp["error"], "cannot unmarshal number into Go struct field")
 	}
 }
 
@@ -142,22 +149,28 @@ func TestDecodeAndValidateRequest_ValidationError(t *testing.T) {
 	dto.MockDTOValidator.EXPECT().Schema().Return(schema)
 
 	// Call the function
-	_, err := DecodeAndValidateRequest(r, dto)
-
-	if err == nil {
-		t.Fatalf("DecodeAndValidateRequest should have returned a validation error")
+	_, ok := DecodeAndValidateRequest(r, dto)
+	if ok {
+		t.Fatal("DecodeAndValidateRequest should have failed")
 	}
 
-	// Check structured error handling
-	var vErr *ValidationError
-	if !errors.As(err, &vErr) {
-		t.Fatalf("Expected ValidationError, got %T", err)
+	// Verify response status and error format
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnprocessableEntity, w.Code)
 	}
 
-	// Check if the error message contains the expected validation error
-	expectedErrorMessage := "validation failed"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		t.Errorf("Error message is incorrect: got %v, want %v", err.Error(), expectedErrorMessage)
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if resp["error"] != "validation failed" {
+		t.Errorf("Expected error 'validation failed', got %v", resp["error"])
+	}
+
+	fields := resp["fields"].(map[string]interface{})
+	if len(fields) == 0 {
+		t.Error("Expected field errors in response")
 	}
 }
 
@@ -178,16 +191,23 @@ func TestDecodeAndValidateRequest_DTOToModelError(t *testing.T) {
 	dto.EXPECT().ToModel().Return(&struct{ Field string }{}, errors.New("invalid model type"))
 
 	// Call the function
-	_, err := DecodeAndValidateRequest(r, dto)
-
-	if err == nil {
-		t.Fatalf("DecodeAndValidateRequest should have returned an error")
+	_, ok := DecodeAndValidateRequest(r, dto)
+	if ok {
+		t.Fatal("DecodeAndValidateRequest should have failed")
 	}
 
-	// Check if the error message contains the expected error
-	expectedErrorMessage := "invalid model type"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		t.Errorf("Error message should contain: %q, got %q", expectedErrorMessage, err.Error())
+	// Verify response status and error format
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if !strings.Contains(resp["error"].(string), "invalid model type") {
+		t.Errorf("Error message should contain: %q, got %q", "invalid model type", resp["error"])
 	}
 }
 
@@ -262,9 +282,9 @@ func TestDecodeAndValidateRequest_WithValidator(t *testing.T) {
 	model := &struct{ Field string }{Field: "valid"}
 	dto.MockDTORequest.EXPECT().ToModel().Return(model, nil)
 
-	result, err := DecodeAndValidateRequest(r, dto)
-	if err != nil {
-		t.Fatalf("Unexpected validation error: %v", err)
+	result, ok := DecodeAndValidateRequest(r, dto)
+	if !ok {
+		t.Fatal("Unexpected validation failure")
 	}
 	if result.Field != "valid" {
 		t.Errorf("Expected model field 'valid', got %q", result.Field)
@@ -284,18 +304,26 @@ func TestDecodeAndValidateRequest_WithValidatorError(t *testing.T) {
 	// Create mock validator and DTO
 	dto := &mockDto{}
 
-	_, err := DecodeAndValidateRequest(r, dto)
-	if err == nil {
-		t.Fatal("Expected validation error, got nil")
-	}
-	var vErr *ValidationError
-	if !errors.As(err, &vErr) {
-		t.Fatalf("Expected ValidationError, got %T", err)
+	_, ok := DecodeAndValidateRequest(r, dto)
+	if ok {
+		t.Fatal("Expected validation failure, got success")
 	}
 
+	// Verify response status and error format
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnprocessableEntity, w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	fields := resp["fields"].(map[string]interface{})
+	fieldErr := fields["field"].(string)
 	expectedErr := "string must contain at least 3 character(s)"
-	if !strings.Contains(vErr.Fields()["field"], expectedErr) {
-		t.Errorf("Expected field error to contain %q, got %q", expectedErr, vErr.Fields()["field"])
+	if !strings.Contains(fieldErr, expectedErr) {
+		t.Errorf("Expected field error to contain %q, got %q", expectedErr, fieldErr)
 	}
 }
 
@@ -307,9 +335,9 @@ func TestDecodeAndValidateRequest_WithoutValidator(t *testing.T) {
 	r := Context(req, w)
 
 	dto := &simpleDTO{}
-	model, err := DecodeAndValidateRequest[simpleModel](r, dto)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	model, ok := DecodeAndValidateRequest[simpleModel](r, dto)
+	if !ok {
+		t.Fatal("Unexpected validation failure")
 	}
 	if model.Name != "test" {
 		t.Errorf("Expected model name 'test', got %q", model.Name)

--- a/http.go
+++ b/http.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-// Encode writes a JSON response to the client. Handles special cases:
-// - Empty slices are encoded as []
-// - Empty maps are encoded as {}
-// - Sets proper Content-Type header
-// - Uses indented JSON for readability
+// Encode writes a JSON response to the client with consistent formatting:
+// - Empty slices/maps render as []/{} instead of null
+// - Sets application/json Content-Type header
+// - Uses indented JSON for human readability
+// - Handles special types through reflection
 func (r RequestContext) Encode(v any) {
 	r.Response.Header().Set("Content-Type", "application/json")
 	// encode nil slices as [] and nil maps as {} (instead of null)
@@ -31,18 +31,18 @@ func (r RequestContext) Encode(v any) {
 }
 
 // Decode reads and parses the request body as JSON into the provided value.
-// Returns:
-// - error with HTTP status 400 if decoding fails
-// - error is wrapped with type information for better error messages
+// Returns an error wrapped with type information if decoding fails
 func (r RequestContext) Decode(v any) error {
 	if err := json.NewDecoder(r.Request.Body).Decode(v); err != nil {
-		return r.Error(fmt.Errorf("couldn't decode request type (%T): %w", v, err), http.StatusBadRequest)
+		return fmt.Errorf("couldn't decode request type (%T): %w", v, err)
 	}
 	return nil
 }
 
-// Error writes an HTTP error response and returns the error. Handles ValidationErrors
-// specially by returning structured JSON responses.
+// Error writes an HTTP error response and returns the error. Formats:
+// - ValidationErrors as 422 Unprocessable Entity with field-specific errors
+// - All other errors as JSON response with "error" field and appropriate status code
+// Maintains consistent JSON formatting for all error responses.
 func (r RequestContext) Error(err error, status int) error {
 	// Handle validation errors with structured response
 	if vErr, ok := err.(*ValidationError); ok {
@@ -55,8 +55,12 @@ func (r RequestContext) Error(err error, status int) error {
 		return err
 	}
 
-	// Default error handling
-	http.Error(r.Response, err.Error(), status)
+	// Default error handling with JSON response
+	r.Response.Header().Set("Content-Type", "application/json")
+	r.Response.WriteHeader(status)
+	json.NewEncoder(r.Response).Encode(map[string]any{
+		"error": err.Error(),
+	})
 	return err
 }
 

--- a/validation.go
+++ b/validation.go
@@ -11,15 +11,20 @@ import (
 	"strings"
 )
 
-// DTOValidator interface
 // DTOValidator defines the validation interface for Data Transfer Objects.
-// Implementations should return a validation schema that will be applied
-// to incoming requests.
+// Implementations should return a zog schema that will be applied to validate
+// incoming requests. The schema is used to:
+// - Validate request structure
+// - Provide meaningful error messages
+// - Ensure data integrity before processing
 type DTOValidator interface {
 	Schema() *z.StructSchema
 }
 
-// ValidationError represents structured validation errors
+// ValidationError represents structured validation failures with:
+// - Field-specific error messages
+// - Machine-readable error codes
+// - Nested error support through error wrapping
 type ValidationError struct {
 	FieldErrors map[string]string // Field path -> error message
 	joinedError error             // Pre-joined error for logging
@@ -56,9 +61,11 @@ func IsValidationError(err error) bool {
 	return errors.As(err, &verr)
 }
 
-// Validate method
-// Validate applies schema validation to the request body using the DTOValidator's schema.
-// Returns a ValidationError containing structured error information when validation fails.
+// Validate applies schema validation to the request body using zog schemas.
+// Returns:
+// - nil on successful validation
+// - ValidationError with field-specific errors on failure
+// - Error wrapping original parse failure if schema validation cannot be performed
 func (r RequestContext) Validate(validator DTOValidator) error {
 	schema := validator.Schema()
 


### PR DESCRIPTION
 • Introduce ErrorHandler interface and DefaultErrorHandler implementation
 • Add VDOption pattern for configuring request processing behavior
 • Update DecodeAndValidateRequest to use error handlers and return boolean status
 • Ensure consistent JSON error responses for all error types
 • Modify tests to verify HTTP responses rather than returned errors

BREAKING CHANGE: DecodeAndValidateRequest return signature changed from (M, error) to (M, bool). Callers must check the boolean return value instead of error handling.