### PR TITLE
feat: add OpenAPI route registration and documentation support

### DIFF
--- a/api_info.go
+++ b/api_info.go
@@ -1,0 +1,63 @@
+package httputil
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+type apiInfo struct {
+	title       string
+	version     string
+	description string
+	contact     *openapi3.Contact
+	license     *openapi3.License
+	terms       string
+}
+
+func APIInfo() *apiInfo {
+	return &apiInfo{}
+}
+
+func (i *apiInfo) Title(title string) *apiInfo {
+	i.title = title
+	return i
+}
+
+func (i *apiInfo) Version(version string) *apiInfo {
+	i.version = version
+	return i
+}
+
+func (i *apiInfo) Description(desc string) *apiInfo {
+	i.description = desc
+	return i
+}
+
+func (i *apiInfo) Contact(email, name string) *apiInfo {
+	i.contact = &openapi3.Contact{
+		Email: email,
+		Name:  name,
+	}
+	return i
+}
+
+func (i *apiInfo) License(name, url string) *apiInfo {
+	i.license = &openapi3.License{
+		Name: name,
+		URL:  url,
+	}
+	return i
+}
+
+func (i *apiInfo) TermsOfService(terms string) *apiInfo {
+	i.terms = terms
+	return i
+}
+
+func (i *apiInfo) toOpenAPI() *openapi3.Info {
+	return &openapi3.Info{
+		Title:          i.title,
+		Version:        i.version,
+		Description:    i.description,
+		Contact:        i.contact,
+		License:        i.license,
+		TermsOfService: i.terms,
+	}
+}

--- a/api_info_test.go
+++ b/api_info_test.go
@@ -1,0 +1,83 @@
+package httputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIInfoBuilder(t *testing.T) {
+	t.Run("basic info", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test API").
+			Version("1.0.0").
+			Description("Test Description").
+			TermsOfService("https://example.com/tos").
+			Contact("support@example.com", "Support Team").
+			License("MIT", "https://opensource.org/licenses/MIT")
+
+		oasInfo := info.toOpenAPI()
+
+		assert.Equal(t, "Test API", oasInfo.Title)
+		assert.Equal(t, "1.0.0", oasInfo.Version)
+		assert.Equal(t, "Test Description", oasInfo.Description)
+		assert.Equal(t, "https://example.com/tos", oasInfo.TermsOfService)
+
+		assert.NotNil(t, oasInfo.Contact)
+		assert.Equal(t, "support@example.com", oasInfo.Contact.Email)
+		assert.Equal(t, "Support Team", oasInfo.Contact.Name)
+
+		assert.NotNil(t, oasInfo.License)
+		assert.Equal(t, "MIT", oasInfo.License.Name)
+		assert.Equal(t, "https://opensource.org/licenses/MIT", oasInfo.License.URL)
+	})
+
+	t.Run("minimum required fields", func(t *testing.T) {
+		info := APIInfo().
+			Title("Minimal API").
+			Version("0.1.0")
+
+		oasInfo := info.toOpenAPI()
+
+		assert.Equal(t, "Minimal API", oasInfo.Title)
+		assert.Equal(t, "0.1.0", oasInfo.Version)
+		assert.Empty(t, oasInfo.Description)
+		assert.Empty(t, oasInfo.TermsOfService)
+		assert.Nil(t, oasInfo.Contact)
+		assert.Nil(t, oasInfo.License)
+	})
+
+	t.Run("contact without name", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test").
+			Version("1.0").
+			Contact("email@test.com", "")
+
+		oasInfo := info.toOpenAPI()
+		assert.Equal(t, "email@test.com", oasInfo.Contact.Email)
+		assert.Empty(t, oasInfo.Contact.Name)
+	})
+
+	t.Run("chaining order", func(t *testing.T) {
+		info1 := APIInfo().Title("A").Version("1")
+		info2 := APIInfo().Version("1").Title("A")
+
+		assert.Equal(t, info1.toOpenAPI(), info2.toOpenAPI())
+	})
+
+	t.Run("nil checks", func(t *testing.T) {
+		// Should not panic when converting nil fields
+		info := APIInfo().Title("Test").Version("1.0")
+		assert.NotPanics(t, func() {
+			_ = info.toOpenAPI()
+		})
+	})
+
+	t.Run("empty builder", func(t *testing.T) {
+		info := APIInfo()
+		oasInfo := info.toOpenAPI()
+
+		assert.Empty(t, oasInfo.Title)
+		assert.Empty(t, oasInfo.Version)
+	})
+}

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,6 @@
 // Package httputil provides HTTP utility functions for building robust web APIs in Go.
-// It implements patterns for type-safe request/response handling with validation and structured error reporting.
+// It implements patterns for type-safe request/response handling with validation, structured error reporting,
+// and OpenAPI documentation generation.
 //
 // Key features:
 // - DTO (Data Transfer Object) pattern for request/response marshaling
@@ -7,6 +8,9 @@
 // - Option pattern configuration for request processing
 // - Automatic error classification and JSON error responses
 // - Context-aware request handling
+// - Integrated OpenAPI/Swagger documentation generation
+// - TUS protocol support for file uploads
+// - Route registration with built-in middleware support
 //
 // The package emphasizes:
 // - Type safety through generics
@@ -14,4 +18,20 @@
 // - Customizable error handling
 // - Consistent JSON formatting
 // - Middleware-ready components
+// - Self-documenting APIs
+//
+// Router Features:
+// - Unified route registration with access control
+// - Automatic OpenAPI spec generation
+// - Built-in support for common patterns:
+//   - Pagination (_start, _end params)
+//   - Sorting (_sort, _order params)
+//   - Filtering (custom field filters)
+//   - Global search (q param)
+// - Predefined Swagger definitions for:
+//   - Authenticated endpoints
+//   - Public endpoints
+//   - File uploads (multipart/form-data)
+//   - TUS protocol endpoints
+//   - Paginated responses
 package httputil

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,116 @@
 module go.lumeweb.com/httputil
 
-go 1.22
+go 1.23.1
+
+toolchain go1.23.7
 
 require (
 	github.com/Oudwins/zog v0.18.4
-	github.com/stretchr/testify v1.9.0
+	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2
+	github.com/stretchr/testify v1.10.0
+	go.lumeweb.com/gswagger v0.0.0-20250524160736-ebc3c0a328ec
+	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
+	go.lumeweb.com/portal-middleware v0.0.0-20250521113541-65cbec90e2a1
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/AfterShip/email-verifier v1.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2 // indirect
+	github.com/aws/smithy-go v1.22.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/boombuler/barcode v1.0.2 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
+	github.com/gammazero/workerpool v1.1.3 // indirect
+	github.com/getkin/kin-openapi v0.132.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-co-op/gocron/v2 v2.16.1 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/go-sql-driver/mysql v1.9.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gookit/event v1.1.2 // indirect
+	github.com/gotd/contrib v0.21.0 // indirect
+	github.com/hbollon/go-edlib v1.6.0 // indirect
+	github.com/invopop/jsonschema v0.12.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/klauspost/reedsolomon v1.12.4 // indirect
+	github.com/knadh/koanf v1.5.0 // indirect
+	github.com/knadh/koanf/v2 v2.1.2 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
+	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
+	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pquerna/otp v1.4.0 // indirect
+	github.com/redis/go-redis/v9 v9.7.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/samber/lo v1.49.1 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
+	github.com/urfave/cli/v3 v3.0.0-beta1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.19 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
+	go.etcd.io/etcd/client/v3 v3.5.19 // indirect
+	go.sia.tech/core v0.10.4 // indirect
+	go.sia.tech/coreutils v0.12.1 // indirect
+	go.sia.tech/jape v0.12.1 // indirect
+	go.sia.tech/mux v1.4.0 // indirect
+	go.sia.tech/renterd v1.1.1 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
+	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/tools v0.31.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
+	google.golang.org/grpc v1.71.0 // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
+	gorm.io/driver/mysql v1.5.7 // indirect
+	gorm.io/gorm v1.25.12 // indirect
+	lukechampine.com/blake3 v1.4.0 // indirect
+	lukechampine.com/frand v1.5.1 // indirect
 )
+
+replace github.com/go-viper/mapstructure/v2 => github.com/LumeWeb/mapstructure/v2 v2.0.0-20241213212524-92525f5828be

--- a/router.go
+++ b/router.go
@@ -1,0 +1,1064 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/gorilla/mux"
+	swagger "go.lumeweb.com/gswagger"
+	gs "go.lumeweb.com/gswagger/support/gorilla"  // Import the specific gorilla support package
+	"go.lumeweb.com/portal-middleware/auth/jwt"   // Assuming your JWT middleware is here
+	"go.lumeweb.com/portal-middleware/middleware" // Assuming your middleware is here
+	"go.lumeweb.com/portal/core"
+)
+
+const (
+	SwaggerJSONPath = "/swagger.json" // Default path for JSON OpenAPI spec
+	SwaggerYAMLPath = "/swagger.yaml" // Default path for YAML OpenAPI spec
+)
+
+// NewSwaggerRouter creates a new gswagger Router instance from a mux.Router with default OpenAPI options.
+// It initializes the OpenAPI specification with the provided API info and sets up standard documentation paths.
+//
+// Parameters:
+//   - muxRouter: The base Gorilla mux router that will handle the actual HTTP requests
+//   - info: API metadata including title, version, description etc (use APIInfo() builder)
+//
+// Returns:
+//   - *swagger.Router: Configured router ready for route registration
+//   - error: Any initialization error
+//
+// Example:
+//
+//	muxRouter := mux.NewRouter()
+//	gRouter, err := NewSwaggerRouter(muxRouter, APIInfo().
+//	    Title("My API").
+//	    Version("1.0.0"))
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func NewSwaggerRouter(muxRouter *mux.Router, info *apiInfo) (*swagger.Router[gs.HandlerFunc, gs.Route], error) {
+	router, err := swagger.NewRouter(gs.NewRouter(muxRouter), swagger.Options{
+		JSONDocumentationPath: SwaggerJSONPath,
+		YAMLDocumentationPath: SwaggerYAMLPath,
+		Openapi: &openapi3.T{
+			Info: info.toOpenAPI(),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return router, nil
+}
+
+// RouteDefinition defines a single HTTP route and its associated documentation and middleware.
+type RouteDefinition struct {
+	// Path is the URL path for the route (e.g., "/users/{id}").
+	Path string
+	// Method is the HTTP method for the route (e.g., "GET", "POST").
+	Method string
+	// Handler is the http.HandlerFunc that handles the request.
+	Handler http.HandlerFunc
+	// Access is the required access role for this route (e.g., core.ACCESS_ADMIN_ROLE).
+	Access string
+	// UseVerify indicates if the AccountVerifiedMiddleware should be applied.
+	UseVerify bool
+	// Use2FA indicates if the 2FA authentication middleware should be applied.
+	Use2FA bool
+	// Swagger contains the OpenAPI definitions for this route.
+	Swagger swagger.Definitions
+}
+
+// RegisterRoutes registers a slice of RouteDefinitions with the provided Mux and gswagger routers.
+// It applies common middleware and specific middleware based on the RouteDefinition flags.
+// It also registers access control for the route.
+func RegisterRoutes(
+	ctx core.Context, // Pass the core context directly
+	muxRouter *mux.Router, // The concrete Mux router
+	gRouter *swagger.Router[gs.HandlerFunc, gs.Route], // gswagger router with gorilla types
+	accessSvc core.AccessService,
+	subdomain string,
+	routes []RouteDefinition,
+	commonMiddleware ...mux.MiddlewareFunc,
+) error {
+	for _, route := range routes {
+		// Create the Mux route
+		muxRoute := muxRouter.HandleFunc(route.Path, route.Handler).Methods(route.Method, "OPTIONS") // Include OPTIONS for CORS
+
+		// Apply specific middleware based on flags
+		if route.UseVerify {
+			muxRoute.Use(middleware.AccountVerifiedMiddleware(ctx))
+		}
+		if route.Use2FA {
+			muxRoute.Use(middleware.AuthMiddleware(ctx, jwt.Purpose2FA))
+		}
+
+		// Apply common middleware
+		muxRoute.Use(commonMiddleware...)
+
+		// Register with gswagger
+		// Since gRouter is typed with gs.HandlerFunc (which is http.HandlerFunc),
+		// the direct assignment works.
+		_, err := gRouter.AddRoute(route.Method, route.Path, gs.HandlerFunc(route.Handler), route.Swagger)
+		if err != nil {
+			return fmt.Errorf("failed to register swagger for route %s %s: %w", route.Method, route.Path, err)
+		}
+
+		// Register access control
+		if route.Access != "" {
+			if accessSvc == nil {
+				return fmt.Errorf("access service required for route %s with access control", route.Path)
+			}
+			if err := accessSvc.RegisterRoute(subdomain, route.Path, route.Method, route.Access); err != nil {
+				return fmt.Errorf("failed to register access for route %s: %w", route.Path, err)
+			}
+		}
+	}
+	return nil
+}
+
+// DefineRoutes is a helper function to create a slice of RouteDefinition
+// from a variable number of arguments.
+// This allows defining routes without explicitly typing the slice literal.
+// Example:
+// routes := httputil.DefineRoutes(
+//
+//	{...}, // RouteDefinition 1
+//	{...}, // RouteDefinition 2
+//
+// )
+func DefineRoutes(routes ...RouteDefinition) []RouteDefinition {
+	return routes
+}
+
+// AuthSwagger generates Swagger definitions for an authenticated endpoint.
+// It includes standard security schemes (Bearer token) and common responses
+// for authentication/authorization failures (401, 403).
+//
+// Parameters:
+// - summary: A brief summary of the operation.
+// - description: A detailed description of the operation.
+// - purpose: The JWT purpose required for this endpoint (e.g., jwt.PurposeLogin).
+// - reqBody: An instance of the request body DTO for schema generation. Can be nil.
+// - respBody: An instance of the success response body DTO for schema generation. Can be nil.
+// - errResp: A map of additional error status codes and example response bodies.
+func AuthSwagger(
+	summary, description string,
+	purpose jwt.Purpose,
+	reqBody any,
+	respBody any,
+	errResp map[int]any,
+) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"Authenticated"},
+		Security: swagger.SecurityRequirements{
+			{
+				"bearerAuth": []string{string(purpose)}, // Assumes "bearerAuth" security scheme is defined globally
+			},
+		},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusOK: {
+				Description: "Success",
+				Content:     swagger.Content{"application/json": {Value: respBody}},
+			},
+			http.StatusUnauthorized: {
+				Description: "Unauthorized - Missing or invalid token",
+				Content:     swagger.Content{"application/json": {Value: map[string]string{"error": "Unauthorized"}}},
+			},
+			http.StatusForbidden: {
+				Description: "Forbidden - Insufficient permissions or unverified account",
+				Content:     swagger.Content{"application/json": {Value: map[string]string{"error": "Forbidden"}}},
+			},
+			http.StatusUnprocessableEntity: {
+				Description: "Validation Failed",
+				Content:     swagger.Content{"application/json": {Value: map[string]any{"error": "validation failed", "fields": map[string]string{}}}},
+			},
+			http.StatusInternalServerError: {
+				Description: "Internal Server Error",
+				Content:     swagger.Content{"application/json": {Value: map[string]string{"error": "Internal Server Error"}}},
+			},
+		},
+	}
+
+	// Add request body if provided
+	if reqBody != nil {
+		definitions.RequestBody = &swagger.ContentValue{
+			Content: swagger.Content{"application/json": {Value: reqBody}},
+			// Note: swagger.Definitions.RequestBody does not have a 'Required' field directly.
+			// This is typically set on the openapi3.RequestBody object itself, which gswagger handles internally.
+			// We can't set 'Required' here in the Definitions struct.
+		}
+	}
+
+	// Add additional error responses
+	for status, body := range errResp {
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status), // Use standard text for description
+			Content:     swagger.Content{"application/json": {Value: body}},
+		}
+	}
+
+	return definitions
+}
+
+// BasicSwagger generates basic Swagger definitions for an endpoint.
+// It does not include authentication security schemes by default.
+//
+// Parameters:
+// - summary: A brief summary of the operation.
+// - description: A detailed description of the operation.
+// - reqBody: An instance of the request body DTO for schema generation. Can be nil.
+// - respBody: An instance of the success response body DTO for schema generation. Can be nil.
+// - errResp: A map of additional error status codes and example response bodies.
+func BasicSwagger(
+	summary, description string,
+	reqBody any,
+	respBody any,
+	errResp map[int]any,
+) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"Public"},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusOK: {
+				Description: "Success",
+				Content:     swagger.Content{"application/json": {Value: respBody}},
+			},
+			http.StatusUnprocessableEntity: {
+				Description: "Validation Failed",
+				Content:     swagger.Content{"application/json": {Value: map[string]any{"error": "validation failed", "fields": map[string]string{}}}},
+			},
+			http.StatusInternalServerError: {
+				Description: "Internal Server Error",
+				Content:     swagger.Content{"application/json": {Value: map[string]string{"error": "Internal Server Error"}}},
+			},
+		},
+	}
+
+	// Add request body if provided
+	if reqBody != nil {
+		definitions.RequestBody = &swagger.ContentValue{
+			Content: swagger.Content{"application/json": {Value: reqBody}},
+			// Note: swagger.Definitions.RequestBody does not have a 'Required' field directly.
+			// This is typically set on the openapi3.RequestBody object itself, which gswagger handles internally.
+			// We can't set 'Required' here in the Definitions struct.
+		}
+	}
+
+	// Add additional error responses
+	for status, body := range errResp {
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status), // Use standard text for description
+			Content:     swagger.Content{"application/json": {Value: body}},
+		}
+	}
+
+	return definitions
+}
+
+// PaginatedResponseSwagger generates Swagger definitions for an endpoint
+// that returns a paginated list of items.
+//
+// Parameters:
+// - summary, description: Standard operation details.
+// - purpose: JWT purpose (for authenticated endpoints). Use jwt.PurposeNone for public.
+// - reqBody: Request body schema (can be nil).
+// - itemSchema: An instance of the schema for a single item in the list.
+// - paginationSchema: An instance of the schema for pagination metadata (can be nil).
+// - errResp: Additional error responses.
+func PaginatedResponseSwagger(
+	summary, description string,
+	purpose jwt.Purpose,
+	reqBody any,
+	itemSchema any,
+	paginationSchema any,
+	errResp map[int]any,
+) swagger.Definitions {
+	// Start with either AuthSwagger or BasicSwagger based on purpose
+	var definitions swagger.Definitions
+	if purpose != jwt.PurposeNone {
+		definitions = AuthSwagger(summary, description, purpose, reqBody, nil, errResp)
+	} else {
+		definitions = BasicSwagger(summary, description, reqBody, nil, errResp)
+	}
+
+	// Define the schema for the paginated response
+	// This is typically an object containing the list of items and pagination metadata
+	paginatedResponseSchema := map[string]any{
+		"items": map[string]any{
+			"type":  "array",
+			"items": itemSchema, // Schema for a single item
+		},
+	}
+
+	// Add pagination metadata schema if provided
+	if paginationSchema != nil {
+		// Assuming paginationSchema is a struct or map that defines the metadata fields
+		// We need to merge its schema into the paginatedResponseSchema
+		// A simple way is to reflect its fields, but a more robust way might involve
+		// using jsonschema.Reflector directly if needed. For simplicity, let's assume
+		// paginationSchema is a map or struct that jsonschema can handle.
+		// A more advanced approach might involve combining schemas using 'allOf'.
+		// For now, let's just add it as a property. This might not be perfect
+		// depending on the exact structure you want.
+		paginatedResponseSchema["pagination"] = paginationSchema
+	}
+
+	// Update the 200 OK response content with the paginated schema
+	definitions.Responses[http.StatusOK] = swagger.ContentValue{
+		Description: "Success",
+		Content:     swagger.Content{"application/json": {Value: paginatedResponseSchema}},
+	}
+
+	return definitions
+}
+
+// FileUploadSwaggerBody generates the RequestBody definition for a file upload endpoint.
+//
+// Parameters:
+// - fileFieldName: The name of the form field for the file.
+// - fileDescription: Description for the file field.
+// - additionalFields: A map of additional form fields (name -> schema value).
+func FileUploadSwaggerBody(
+	fileFieldName string,
+	fileDescription string,
+	additionalFields map[string]any,
+) *swagger.ContentValue {
+	properties := map[string]any{
+		fileFieldName: map[string]any{
+			"type":        "string",
+			"format":      "binary", // Indicates file upload
+			"description": fileDescription,
+		},
+	}
+
+	// Add additional form fields
+	for name, schemaValue := range additionalFields {
+		properties[name] = schemaValue
+	}
+
+	return &swagger.ContentValue{
+		Content: swagger.Content{
+			"multipart/form-data": {
+				Value: map[string]any{
+					"type":       "object",
+					"properties": properties,
+				},
+			},
+		},
+		//Required: true, // File uploads typically require a body
+	}
+}
+
+// WithPathParam adds a path parameter definition to existing Swagger definitions.
+// This is intended to be chained.
+func WithPathParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+	if d.PathParams == nil {
+		d.PathParams = make(swagger.ParameterValue)
+	}
+	d.PathParams[name] = swagger.Parameter{
+		Description: description,
+		Schema:      &swagger.Schema{Value: schemaValue},
+	}
+	return d
+}
+
+// WithQueryParam adds a query parameter definition to existing Swagger definitions.
+// This is intended to be chained.
+func WithQueryParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+	if d.Querystring == nil {
+		d.Querystring = make(swagger.ParameterValue)
+	}
+	d.Querystring[name] = swagger.Parameter{
+		Description: description,
+		Schema:      &swagger.Schema{Value: schemaValue},
+	}
+	return d
+}
+
+// WithHeaderParam adds a header parameter definition to existing Swagger definitions.
+// This is intended to be chained.
+func WithHeaderParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+	if d.Headers == nil {
+		d.Headers = make(swagger.ParameterValue)
+	}
+	d.Headers[name] = swagger.Parameter{
+		Description: description,
+		Schema:      &swagger.Schema{Value: schemaValue},
+	}
+	return d
+}
+
+// WithCookieParam adds a cookie parameter definition to existing Swagger definitions.
+// This is intended to be chained.
+func WithCookieParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+	if d.Cookies == nil {
+		d.Cookies = make(swagger.ParameterValue)
+	}
+	d.Cookies[name] = swagger.Parameter{
+		Description: description,
+		Schema:      &swagger.Schema{Value: schemaValue},
+	}
+	return d
+}
+
+// EmptyResponseSwagger generates the Swagger definition for a 200 OK response with no body.
+func EmptyResponseSwagger() swagger.ContentValue {
+	return swagger.ContentValue{
+		Description: "Success",
+		Content:     nil, // Or an empty map: swagger.Content{}
+	}
+}
+
+// ErrorResponseSwagger generates a map for a single additional error response.
+// Useful for adding one-off custom error responses to the errResp map.
+func ErrorResponseSwagger(status int, body any) map[int]any {
+	return map[int]any{
+		status: body,
+	}
+}
+
+// WithPaginationParams adds standard pagination query parameters (_start, _end) to Swagger definitions.
+// It takes the base Swagger definitions and returns the modified definitions for chaining.
+func WithPaginationParams(d swagger.Definitions) swagger.Definitions {
+	if d.Querystring == nil {
+		d.Querystring = make(swagger.ParameterValue)
+	}
+	d.Querystring["_start"] = swagger.Parameter{
+		Description: "Starting index of the items to return (0-based). Defaults to 0.",
+		Schema:      &swagger.Schema{Value: 0}, // Example value for schema generation
+	}
+	d.Querystring["_end"] = swagger.Parameter{
+		Description: "Ending index of the items to return (exclusive). Defaults to 10.",
+		Schema:      &swagger.Schema{Value: 10}, // Example value for schema generation
+	}
+	return d
+}
+
+// WithSortParams adds standard sorting query parameters (_sort, _order) to Swagger definitions.
+// It takes the base Swagger definitions and returns the modified definitions for chaining.
+//
+// Parameters:
+// - d: The base Swagger definitions.
+// - sortableFields: A list of fields that can be sorted. Used in the description.
+func WithSortParams(d swagger.Definitions, sortableFields []string) swagger.Definitions {
+	if d.Querystring == nil {
+		d.Querystring = make(swagger.ParameterValue)
+	}
+	d.Querystring["_sort"] = swagger.Parameter{
+		Description: fmt.Sprintf("Comma-separated list of fields to sort by. Available fields: %s", strings.Join(sortableFields, ", ")),
+		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+	}
+	d.Querystring["_order"] = swagger.Parameter{
+		Description: "Comma-separated list of sort orders ('asc' or 'desc') corresponding to _sort fields. Defaults to 'asc'.",
+		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+	}
+	return d
+}
+
+// WithFilterParam adds a single filter query parameter to Swagger definitions.
+// This helper is for simple filters like `fieldName_operator=value`.
+//
+// Parameters:
+// - d: The base Swagger definitions.
+// - name: The full query parameter name (e.g., "age_gte", "status_eq").
+// - description: Description of the filter parameter.
+// - schemaValue: An example value for schema generation (e.g., 30, "active").
+func WithFilterParam(d swagger.Definitions, name, description string, schemaValue any) swagger.Definitions {
+	if d.Querystring == nil {
+		d.Querystring = make(swagger.ParameterValue)
+	}
+	d.Querystring[name] = swagger.Parameter{
+		Description: description,
+		Schema:      &swagger.Schema{Value: schemaValue},
+	}
+	return d
+}
+
+// WithGlobalSearchParam adds the standard global search query parameter ('q') to Swagger definitions.
+// It takes the base Swagger definitions and returns the modified definitions for chaining.
+func WithGlobalSearchParam(d swagger.Definitions) swagger.Definitions {
+	if d.Querystring == nil {
+		d.Querystring = make(swagger.ParameterValue)
+	}
+	d.Querystring["q"] = swagger.Parameter{
+		Description: "Global search query string.",
+		Schema:      &swagger.Schema{Value: ""}, // Example value (string)
+	}
+	return d
+}
+
+// FilterParam defines the details for a single filter query parameter.
+type FilterParam struct {
+	Name        string // The full query parameter name (e.g., "age_gte", "status_eq")
+	Description string
+	SchemaValue any // An example value for schema generation
+}
+
+// ListEndpointSwagger generates comprehensive Swagger definitions for a typical list endpoint.
+// It includes authentication, pagination, sorting, global search, and specific filter parameters.
+//
+// Parameters:
+// - summary, description: Standard operation details.
+// - purpose: JWT purpose (for authenticated endpoints). Use jwt.PurposeNone for public.
+// - itemSchema: An instance of the schema for a single item in the list response.
+// - paginationSchema: An instance of the schema for pagination metadata in the response (can be nil).
+// - sortableFields: A list of fields that can be sorted.
+// - filterParams: A slice of FilterParam structs defining additional filter query parameters.
+// - errResp: Additional error responses.
+func ListEndpointSwagger(
+	summary, description string,
+	purpose jwt.Purpose,
+	itemSchema any,
+	paginationSchema any,
+	sortableFields []string,
+	filterParams []FilterParam,
+	errResp map[int]any,
+) swagger.Definitions {
+	// Start with the base Swagger definitions (authenticated or public)
+	var definitions swagger.Definitions
+	if purpose != jwt.PurposeNone {
+		definitions = AuthSwagger(summary, description, purpose, nil, nil, errResp)
+	} else {
+		definitions = BasicSwagger(summary, description, nil, nil, errResp)
+	}
+
+	// Add standard query parameters using the chaining helpers
+	definitions = WithPaginationParams(definitions)
+	definitions = WithSortParams(definitions, sortableFields)
+	definitions = WithGlobalSearchParam(definitions)
+
+	// Add specific filter parameters
+	for _, fp := range filterParams {
+		definitions = WithQueryParam(definitions, fp.Name, fp.Description, fp.SchemaValue)
+	}
+
+	// Update the 200 OK response content with the paginated schema
+	// Use PaginatedResponseSwagger logic directly
+	paginatedResponseSchema := map[string]any{
+		"items": map[string]any{
+			"type":  "array",
+			"items": itemSchema, // Schema for a single item
+		},
+	}
+	if paginationSchema != nil {
+		paginatedResponseSchema["pagination"] = paginationSchema
+	}
+
+	definitions.Responses[http.StatusOK] = swagger.ContentValue{
+		Description: "Success",
+		Content:     swagger.Content{"application/json": {Value: paginatedResponseSchema}},
+	}
+
+	return definitions
+}
+
+// Schema helpers provide safe access to schema fields
+func getSchemaDescription(schema *swagger.Schema) string {
+	if schema == nil || schema.Value == nil {
+		return ""
+	}
+	if valMap, ok := schema.Value.(map[string]any); ok {
+		if desc, ok := valMap["description"].(string); ok {
+			return desc
+		}
+	}
+	return ""
+}
+
+func getSchemaEnum(schema *swagger.Schema) []string {
+	if schema == nil || schema.Value == nil {
+		return nil
+	}
+	if valMap, ok := schema.Value.(map[string]any); ok {
+		if enum, ok := valMap["enum"].([]string); ok {
+			return enum
+		}
+		if enumAny, ok := valMap["enum"].([]any); ok {
+			enum := make([]string, len(enumAny))
+			for i, v := range enumAny {
+				if s, ok := v.(string); ok {
+					enum[i] = s
+				}
+			}
+			return enum
+		}
+	}
+	return nil
+}
+
+// Define reusable schemas for common TUS headers
+var (
+	tusResumableSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"enum":        []string{"1.0.0"},
+			"description": "Protocol version",
+		},
+	}
+	tusVersionSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"description": "The Tus-Version response header MUST be a comma-separated list of protocol versions supported by the Server. The list MUST be sorted by Server's preference where the first one is the most preferred one.",
+		},
+	}
+	tusExtensionSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"description": "The Tus-Extension response header MUST be a comma-separated list of the extensions supported by the Server. If no extensions are supported, the Tus-Extension header MUST be omitted.",
+		},
+	}
+	tusMaxSizeSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "integer",
+			"description": "The Tus-Max-Size response header MUST be a non-negative integer indicating the maximum allowed size of an entire upload in bytes. The Server SHOULD set this header if there is a known hard limit.",
+		},
+	}
+	uploadLengthSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "integer",
+			"description": "The Upload-Length request and response header indicates the size of the entire upload in bytes. The value MUST be a non-negative integer. In the concatenation extension, the Client MUST NOT include the Upload-Length header in the final upload creation",
+		},
+	}
+	uploadOffsetSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "integer",
+			"description": "The Upload-Offset request and response header indicates a byte offset within a resource. The value MUST be a non-negative integer.",
+		},
+	}
+	tusChecksumAlgorithmSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"description": "Added by the checksum extension. The Tus-Checksum-Algorithm response header MUST be a comma-separated list of the checksum algorithms supported by the server.",
+		},
+	}
+	uploadChecksumSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"description": "Added by the checksum extension. The Upload-Checksum request header contains information about the checksum of the current body payload. The header MUST consist of the name of the used checksum algorithm and the Base64 encoded checksum separated by a space.",
+		},
+	}
+	uploadExpiresSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"format":      "date-time", // RFC 7231 datetime format
+			"description": "Added by the expiration extension. The Upload-Expires response header indicates the time after which the unfinished upload expires. A Server MAY wish to remove incomplete uploads after a given period of time to prevent abandoned uploads from taking up extra storage. The Client SHOULD use this header to determine if an upload is still valid before attempting to resume the upload. This header MUST be included in every PATCH response if the upload is going to expire. If the expiration is known at the creation, the Upload-Expires header MUST be included in the response to the initial POST request. Its value MAY change over time. If a Client does attempt to resume an upload which has since been removed by the Server, the Server SHOULD respond with the 404 Not Found or 410 Gone status. The latter one SHOULD be used if the Server is keeping track of expired uploads. In both cases the Client SHOULD start a new upload. The value of the Upload-Expires header MUST be in RFC 7231 datetime format.",
+		},
+	}
+	locationSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type":        "string",
+			"format":      "url",
+			"description": "Url of the created resource.",
+		},
+	}
+	cacheControlSchema = &swagger.Schema{
+		Value: map[string]any{
+			"type": "string",
+			"enum": []string{"no-store"},
+		},
+	}
+)
+
+// TusPostSwagger generates Swagger definitions for the TUS POST /files operation.
+func TusPostSwagger(summary, description string, errResp map[int]any) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"TUS"},
+		Parameters: map[string]swagger.ParameterDefinition{ // Corrected type
+			"Content-Length": {
+				In:          "header",
+				Description: "Must be 0 for creation extension. May be a positive number for Creation With Upload extension.",
+				Schema:      &swagger.Schema{Value: 0}, // Example value
+			},
+			"Upload-Length": {
+				In:       "header",
+				Required: true, // Required by core protocol for initial creation
+				Schema:   uploadLengthSchema,
+			},
+			"Tus-Resumable": {
+				In:       "header",
+				Required: true,
+				Schema:   tusResumableSchema,
+			},
+			"Upload-Metadata": {
+				In:          "header",
+				Description: "Added by the Creation extension. The Upload-Metadata request and response header MUST consist of one or more comma-separated key-value pairs. The key and value MUST be separated by a space. The key MUST NOT contain spaces and commas and MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST be Base64 encoded. All keys MUST be unique. The value MAY be empty. In these cases, the space, which would normally separate the key and the value, MAY be left out. Since metadata can contain arbitrary binary values, Servers SHOULD carefully validate metadata values or sanitize them before using them as header values to avoid header smuggling.",
+				Schema:      &swagger.Schema{Value: "filename bXktZmlsZS50eHQ="}, // Example value
+			},
+			"Upload-Concat": {
+				In:          "header",
+				Description: "Added by the Concatenation extension. Indicates whether the upload is either a partial or final upload.",
+				Schema:      &swagger.Schema{Value: "partial"}, // Example value
+			},
+			"Upload-Defer-Length": {
+				In:          "header",
+				Description: "Added by the Creation Defer Length extension. Indicates that the size of the upload is not known currently.",
+				Schema:      &swagger.Schema{Value: 1}, // Example value
+			},
+			"Upload-Offset": { // Included for Creation With Upload extension
+				In:          "header",
+				Description: "Added by the Creation With Upload Extension. Indicates the offset of the included data.",
+				Schema:      uploadOffsetSchema,
+			},
+			"Upload-Checksum": { // Added by the Creation With Upload extension in combination with the checksum extension
+				In:          "header",
+				Description: "Added by the Creation With Upload Extension in combination with the checksum extension. Checksum of the included data.",
+				Schema:      uploadChecksumSchema,
+			},
+		},
+		RequestBody: &swagger.ContentValue{
+			Description: "Remaining (possibly partial) content of the file. Required if Content-Length > 0.",
+			Required:    false, // Only required if Content-Length > 0
+			Content: swagger.Content{
+				"application/offset+octet-stream": {
+					Value: map[string]any{
+						"type":   "string",
+						"format": "binary",
+					},
+				},
+			},
+		},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusCreated: {
+				Description: "Created",
+				Headers: map[string]string{
+					"Tus-Resumable":  getSchemaDescription(tusResumableSchema),
+					"Upload-Offset":  getSchemaDescription(uploadOffsetSchema),
+					"Upload-Expires": getSchemaDescription(uploadExpiresSchema),
+					"Location":       getSchemaDescription(locationSchema),
+				},
+			},
+			http.StatusBadRequest: { // 400 Bad Request (e.g., Checksum algorithm not supported)
+				Description: "Bad Request",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusPreconditionFailed: { // 412 Precondition Failed (e.g., Tus-Version mismatch)
+				Description: "Precondition Failed",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+					"Tus-Version":   getSchemaDescription(tusVersionSchema),
+				},
+			},
+			http.StatusRequestEntityTooLarge: { // 413 Request Entity Too Large
+				Description: "Request Entity Too Large",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusUnsupportedMediaType: { // 415 Unsupported Media Type (e.g., Content-Type not application/offset+octet-stream)
+				Description: "Unsupported Media Type",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			460: { // 460 Checksum Mismatch
+				Description: "Checksums mismatch",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+		},
+	}
+
+	// Add additional error responses
+	for status, v := range errResp { // Iterate over map[int]any
+		// Assuming errResp values are schema examples, wrap them in ContentValue
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status),
+			Content:     swagger.Content{"application/json": {Value: v}},
+		}
+	}
+
+	return definitions
+}
+
+// TusHeadSwagger generates Swagger definitions for the TUS HEAD /files/{id} operation.
+func TusHeadSwagger(summary, description string, errResp map[int]any) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"TUS"},
+		Parameters: map[string]swagger.ParameterDefinition{ // Corrected type
+			"id": {
+				In:          "path",
+				Required:    true,
+				Description: "The ID of the upload resource.",
+				Schema:      &swagger.Schema{Value: "string"}, // Example value
+			},
+			"Tus-Resumable": {
+				In:       "header",
+				Required: true,
+				Schema:   tusResumableSchema,
+			},
+		},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusOK: {
+				Description: "Returns offset",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+					"Cache-Control": getSchemaDescription(cacheControlSchema),
+					"Upload-Offset": getSchemaDescription(uploadOffsetSchema),
+					"Upload-Length": getSchemaDescription(uploadLengthSchema),
+				},
+			},
+			http.StatusForbidden: { // 403 Forbidden
+				Description: "Forbidden",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusNotFound: { // 404 Not Found
+				Description: "Not Found",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusGone: { // 410 Gone
+				Description: "Gone",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusPreconditionFailed: { // 412 Precondition Failed
+				Description: "Precondition Failed",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+					"Tus-Version":   getSchemaDescription(tusVersionSchema),
+				},
+			},
+		},
+	}
+
+	// Add additional error responses
+	for status, v := range errResp { // Iterate over map[int]any
+		// Assuming errResp values are schema examples, wrap them in ContentValue
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status),
+			Content:     swagger.Content{"application/json": {Value: v}},
+		}
+	}
+
+	return definitions
+}
+
+// TusPatchSwagger generates Swagger definitions for the TUS PATCH /files/{id} operation.
+func TusPatchSwagger(summary, description string, errResp map[int]any) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"TUS"},
+		Parameters: map[string]swagger.ParameterDefinition{ // Corrected type
+			"id": {
+				In:          "path",
+				Required:    true,
+				Description: "The ID of the upload resource.",
+				Schema:      &swagger.Schema{Value: "string"}, // Example value
+			},
+			"Tus-Resumable": {
+				In:       "header",
+				Required: true,
+				Schema:   tusResumableSchema,
+			},
+			"Content-Length": {
+				In:          "header",
+				Required:    true,
+				Description: "Length of the body of this request",
+				Schema:      &swagger.Schema{Value: 0}, // Example value
+			},
+			"Upload-Offset": {
+				In:          "header",
+				Required:    true,
+				Description: "The offset at which the upload should be continued.",
+				Schema:      uploadOffsetSchema,
+			},
+			"Upload-Checksum": {
+				In:          "header",
+				Description: "Added by the checksum extension. Checksum of the current body payload.",
+				Schema:      uploadChecksumSchema,
+			},
+		},
+		RequestBody: &swagger.ContentValue{
+			Description: "Remaining (possibly partial) content of the file. Required if Content-Length > 0.",
+			Required:    false, // Only required if Content-Length > 0
+			Content: swagger.Content{
+				"application/offset+octet-stream": {
+					Value: map[string]any{
+						"type":   "string",
+						"format": "binary",
+					},
+				},
+			},
+		},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusNoContent: { // 204 No Content
+				Description: "Upload offset was updated",
+				Headers: map[string]string{
+					"Tus-Resumable":  getSchemaDescription(tusResumableSchema),
+					"Upload-Offset":  getSchemaDescription(uploadOffsetSchema),
+					"Upload-Expires": getSchemaDescription(uploadExpiresSchema),
+				},
+			},
+			http.StatusBadRequest: { // 400 Bad Request (e.g., Checksum algorithm not supported)
+				Description: "Bad Request",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusForbidden: { // 403 Forbidden (e.g., PATCH against a final upload URL)
+				Description: "Forbidden",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusNotFound: { // 404 Not Found
+				Description: "Not Found",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusConflict: { // 409 Conflict (Upload-Offset mismatch)
+				Description: "Conflict",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusGone: { // 410 Gone
+				Description: "Gone",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusPreconditionFailed: { // 412 Precondition Failed
+				Description: "Precondition Failed",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+					"Tus-Version":   getSchemaDescription(tusVersionSchema),
+				},
+			},
+			http.StatusUnsupportedMediaType: { // 415 Unsupported Media Type
+				Description: "Unsupported Media Type",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			460: { // 460 Checksum Mismatch
+				Description: "Checksums mismatch",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+		},
+	}
+
+	// Add additional error responses
+	for status, v := range errResp { // Iterate over map[int]any
+		// Assuming errResp values are schema examples, wrap them in ContentValue
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status),
+			Content:     swagger.Content{"application/json": {Value: v}},
+		}
+	}
+
+	return definitions
+}
+
+// TusDeleteSwagger generates Swagger definitions for the TUS DELETE /files/{id} operation.
+func TusDeleteSwagger(summary, description string, errResp map[int]any) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"TUS"},
+		Parameters: map[string]swagger.ParameterDefinition{ // Corrected type
+			"id": {
+				In:          "path",
+				Required:    true,
+				Description: "The ID of the upload resource.",
+				Schema:      &swagger.Schema{Value: "string"}, // Example value
+			},
+			"Tus-Resumable": {
+				In:       "header",
+				Required: true,
+				Schema:   tusResumableSchema,
+			},
+		},
+		Responses: map[int]swagger.ContentValue{
+			http.StatusNoContent: { // 204 No Content
+				Description: "Upload was terminated",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+				},
+			},
+			http.StatusPreconditionFailed: { // 412 Precondition Failed
+				Description: "Precondition Failed",
+				Headers: map[string]string{
+					"Tus-Resumable": getSchemaDescription(tusResumableSchema),
+					"Tus-Version":   getSchemaDescription(tusVersionSchema),
+				},
+			},
+		},
+	}
+
+	// Add additional error responses
+	for status, v := range errResp { // Iterate over map[int]any
+		// Assuming errResp values are schema examples, wrap them in ContentValue
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status),
+			Content:     swagger.Content{"application/json": {Value: v}},
+		}
+	}
+
+	return definitions
+}
+
+// TusOptionsSwagger generates Swagger definitions for the TUS OPTIONS /files operation.
+func TusOptionsSwagger(summary, description string, errResp map[int]any) swagger.Definitions {
+	definitions := swagger.Definitions{
+		Summary:     summary,
+		Description: description,
+		Tags:        []string{"TUS"},
+		Parameters:  map[string]swagger.ParameterDefinition{}, // OPTIONS typically has no request parameters defined in the spec
+		Responses: map[int]swagger.ContentValue{
+			http.StatusOK: { // 200 OK
+				Description: "Success",
+				Headers: map[string]string{
+					"Tus-Resumable":          getSchemaDescription(tusResumableSchema),
+					"Tus-Checksum-Algorithm": getSchemaDescription(tusChecksumAlgorithmSchema),
+					"Tus-Version":            getSchemaDescription(tusVersionSchema),
+					"Tus-Max-Size":           getSchemaDescription(tusMaxSizeSchema),
+					"Tus-Extension":          getSchemaDescription(tusExtensionSchema),
+				},
+			},
+			http.StatusNoContent: { // 204 No Content
+				Description: "Success",
+				Headers: map[string]string{
+					"Tus-Resumable":          getSchemaDescription(tusResumableSchema),
+					"Tus-Checksum-Algorithm": getSchemaDescription(tusChecksumAlgorithmSchema),
+					"Tus-Version":            getSchemaDescription(tusVersionSchema),
+					"Tus-Max-Size":           getSchemaDescription(tusMaxSizeSchema),
+					"Tus-Extension":          getSchemaDescription(tusExtensionSchema),
+				},
+			},
+		},
+	}
+
+	// Add additional error responses
+	for status, v := range errResp { // Iterate over map[int]any
+		// Assuming errResp values are schema examples, wrap them in ContentValue
+		definitions.Responses[status] = swagger.ContentValue{
+			Description: http.StatusText(status),
+			Content:     swagger.Content{"application/json": {Value: v}},
+		}
+	}
+
+	return definitions
+}

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,261 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	swagger "go.lumeweb.com/gswagger"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
+)
+
+func TestRegisterRoutes(t *testing.T) {
+	tests := []struct {
+		name              string
+		routes           []RouteDefinition
+		accessSvcErr     error
+		wantRegisterErr  bool
+		wantSwaggerGenErr bool
+		wantAccessReg    bool
+	}{
+		{
+			name: "successful registration",
+			routes: []RouteDefinition{
+				{
+					Path:    "/test",
+					Method:  "GET",
+					Handler: func(w http.ResponseWriter, r *http.Request) {},
+				},
+			},
+			wantRegisterErr:  false,
+			wantSwaggerGenErr: false,
+			wantAccessReg:    false,
+		},
+		{
+			name: "with access control",
+			routes: []RouteDefinition{
+				{
+					Path:    "/secure",
+					Method:  "GET",
+					Handler: func(w http.ResponseWriter, r *http.Request) {},
+					Access:  "admin",
+				},
+			},
+			wantRegisterErr:  false,
+			wantSwaggerGenErr: false,
+			wantAccessReg:    true,
+		},
+		{
+			name: "access service error",
+			routes: []RouteDefinition{
+				{
+					Path:    "/secure",
+					Method:  "GET",
+					Handler: func(w http.ResponseWriter, r *http.Request) {},
+					Access:  "admin",
+				},
+			},
+			accessSvcErr:     assert.AnError,
+			wantRegisterErr:  true,
+			wantSwaggerGenErr: false,
+			wantAccessReg:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			muxRouter := mux.NewRouter()
+			gRouter, err := NewSwaggerRouter(muxRouter, APIInfo().
+				Title("Test API").
+				Version("1.0.0"))
+			require.NoError(t, err)
+			accessSvc := coreMocks.NewMockAccessService(t)
+			ctx := coreTesting.NewTestContext(t)
+
+			if tt.wantAccessReg || tt.accessSvcErr != nil {
+				// If access registration is expected OR an access service error is expected,
+				// set up the mock to be called and return the specified error.
+				accessSvc.On("RegisterRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(tt.accessSvcErr).Once()
+			} else {
+				// Otherwise, assert that RegisterRoute is not called.
+				accessSvc.AssertNotCalled(t, "RegisterRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			}
+
+			err = RegisterRoutes(ctx, muxRouter, gRouter, accessSvc, "test", tt.routes)
+
+			if tt.wantRegisterErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			accessSvc.AssertExpectations(t)
+
+			// Generate OpenAPI spec after routes are registered
+			err = gRouter.GenerateAndExposeOpenapi()
+			if tt.wantSwaggerGenErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify routes are registered by making test requests
+			for _, route := range tt.routes {
+				req := httptest.NewRequest(route.Method, route.Path, nil)
+				rr := httptest.NewRecorder()
+				muxRouter.ServeHTTP(rr, req)
+				assert.NotEqual(t, http.StatusNotFound, rr.Code)
+			}
+		})
+	}
+}
+
+func TestDefineRoutes(t *testing.T) {
+	r1 := RouteDefinition{Path: "/one"}
+	r2 := RouteDefinition{Path: "/two"}
+
+	routes := DefineRoutes(r1, r2)
+
+	assert.Len(t, routes, 2)
+	assert.Equal(t, "/one", routes[0].Path)
+	assert.Equal(t, "/two", routes[1].Path)
+}
+
+func TestAuthSwagger(t *testing.T) {
+	def := AuthSwagger(
+		"Test Summary",
+		"Test Description",
+		jwt.PurposeLogin,
+		nil,
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, "Test Summary", def.Summary)
+	assert.Equal(t, "Test Description", def.Description)
+	assert.Contains(t, def.Tags, "Authenticated")
+	assert.NotEmpty(t, def.Security)
+	assert.Contains(t, def.Responses, http.StatusOK)
+	assert.Contains(t, def.Responses, http.StatusUnauthorized)
+	assert.Contains(t, def.Responses, http.StatusForbidden)
+}
+
+func TestBasicSwagger(t *testing.T) {
+	def := BasicSwagger(
+		"Test Summary",
+		"Test Description",
+		nil,
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, "Test Summary", def.Summary)
+	assert.Equal(t, "Test Description", def.Description)
+	assert.Contains(t, def.Tags, "Public")
+	assert.Contains(t, def.Responses, http.StatusOK)
+	assert.NotContains(t, def.Security, "bearerAuth")
+}
+
+func TestWithPathParam(t *testing.T) {
+	def := swagger.Definitions{}
+	def = WithPathParam(def, "id", "Test ID", "string")
+
+	assert.NotNil(t, def.PathParams)
+	assert.Equal(t, "Test ID", def.PathParams["id"].Description)
+}
+
+func TestWithQueryParam(t *testing.T) {
+	def := swagger.Definitions{}
+	def = WithQueryParam(def, "filter", "Test filter", "string")
+
+	assert.NotNil(t, def.Querystring)
+	assert.Equal(t, "Test filter", def.Querystring["filter"].Description)
+}
+
+func TestWithPaginationParams(t *testing.T) {
+	def := swagger.Definitions{}
+	def = WithPaginationParams(def)
+
+	assert.NotNil(t, def.Querystring)
+	assert.Contains(t, def.Querystring, "_start")
+	assert.Contains(t, def.Querystring, "_end")
+}
+
+func TestNewSwaggerRouter(t *testing.T) {
+	muxRouter := mux.NewRouter()
+	gRouter, err := NewSwaggerRouter(muxRouter, APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, gRouter)
+}
+
+func TestSwaggerDocsServed(t *testing.T) {
+	muxRouter := mux.NewRouter()
+	gRouter, err := NewSwaggerRouter(muxRouter, APIInfo().
+		Title("Test API").
+		Version("1.0.0"))
+	require.NoError(t, err)
+	require.NotNil(t, gRouter)
+
+	// Register a test route first
+	routes := DefineRoutes(
+		RouteDefinition{
+			Path:    "/test",
+			Method:  "GET",
+			Handler: func(w http.ResponseWriter, r *http.Request) {},
+		},
+	)
+	err = RegisterRoutes(coreTesting.NewTestContext(t), muxRouter, gRouter, nil, "", routes)
+	require.NoError(t, err)
+
+	// Now generate the OpenAPI spec
+	err = gRouter.GenerateAndExposeOpenapi()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		path     string
+		wantCode int
+	}{
+		{
+			name:     "JSON docs",
+			path:     SwaggerJSONPath,
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "YAML docs",
+			path:     SwaggerYAMLPath,
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			rr := httptest.NewRecorder()
+			muxRouter.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantCode, rr.Code)
+			assert.NotEmpty(t, rr.Body.String())
+		})
+	}
+}
+
+func TestWithSortParams(t *testing.T) {
+	def := swagger.Definitions{}
+	def = WithSortParams(def, []string{"name", "date"})
+
+	assert.NotNil(t, def.Querystring)
+	assert.Contains(t, def.Querystring, "_sort")
+	assert.Contains(t, def.Querystring, "_order")
+	assert.Contains(t, def.Querystring["_sort"].Description, "name, date")
+}


### PR DESCRIPTION
Introduce structured route definitions with built-in OpenAPI/Swagger documentation generation. Enables declarative API registration with:

- Automatic OpenAPI spec generation
- Route metadata and security configuration
- Middleware integration points
- Standardized response schemas
- TUS protocol support