### PR TITLE
refactor(router): simplify route registration by removing direct mux.Router dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Oudwins/zog v0.18.4
 	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.0.0-20250524160736-ebc3c0a328ec
+	go.lumeweb.com/gswagger v0.0.0-20250525010010-2480f51b33ba
 	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02
 	go.lumeweb.com/portal-middleware v0.0.0-20250521113541-65cbec90e2a1
 )

--- a/router.go
+++ b/router.go
@@ -77,13 +77,15 @@ type RouteDefinition struct {
 // It also registers access control for the route.
 func RegisterRoutes(
 	ctx core.Context, // Pass the core context directly
-	muxRouter *mux.Router, // The concrete Mux router
 	gRouter *swagger.Router[gs.HandlerFunc, gs.Route], // gswagger router with gorilla types
 	accessSvc core.AccessService,
 	subdomain string,
 	routes []RouteDefinition,
 	commonMiddleware ...mux.MiddlewareFunc,
 ) error {
+
+	muxRouter := swagger.GetRouter[*mux.Router, gs.HandlerFunc, gs.Route](gRouter.Router())
+
 	for _, route := range routes {
 		// Create the Mux route
 		muxRoute := muxRouter.HandleFunc(route.Path, route.Handler).Methods(route.Method, "OPTIONS") // Include OPTIONS for CORS

--- a/router_test.go
+++ b/router_test.go
@@ -18,11 +18,11 @@ import (
 func TestRegisterRoutes(t *testing.T) {
 	tests := []struct {
 		name              string
-		routes           []RouteDefinition
-		accessSvcErr     error
-		wantRegisterErr  bool
+		routes            []RouteDefinition
+		accessSvcErr      error
+		wantRegisterErr   bool
 		wantSwaggerGenErr bool
-		wantAccessReg    bool
+		wantAccessReg     bool
 	}{
 		{
 			name: "successful registration",
@@ -33,9 +33,9 @@ func TestRegisterRoutes(t *testing.T) {
 					Handler: func(w http.ResponseWriter, r *http.Request) {},
 				},
 			},
-			wantRegisterErr:  false,
+			wantRegisterErr:   false,
 			wantSwaggerGenErr: false,
-			wantAccessReg:    false,
+			wantAccessReg:     false,
 		},
 		{
 			name: "with access control",
@@ -47,9 +47,9 @@ func TestRegisterRoutes(t *testing.T) {
 					Access:  "admin",
 				},
 			},
-			wantRegisterErr:  false,
+			wantRegisterErr:   false,
 			wantSwaggerGenErr: false,
-			wantAccessReg:    true,
+			wantAccessReg:     true,
 		},
 		{
 			name: "access service error",
@@ -61,10 +61,10 @@ func TestRegisterRoutes(t *testing.T) {
 					Access:  "admin",
 				},
 			},
-			accessSvcErr:     assert.AnError,
-			wantRegisterErr:  true,
+			accessSvcErr:      assert.AnError,
+			wantRegisterErr:   true,
 			wantSwaggerGenErr: false,
-			wantAccessReg:    true,
+			wantAccessReg:     true,
 		},
 	}
 
@@ -88,7 +88,7 @@ func TestRegisterRoutes(t *testing.T) {
 				accessSvc.AssertNotCalled(t, "RegisterRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			}
 
-			err = RegisterRoutes(ctx, muxRouter, gRouter, accessSvc, "test", tt.routes)
+			err = RegisterRoutes(ctx, gRouter, accessSvc, "test", tt.routes)
 
 			if tt.wantRegisterErr {
 				assert.Error(t, err)
@@ -214,7 +214,7 @@ func TestSwaggerDocsServed(t *testing.T) {
 			Handler: func(w http.ResponseWriter, r *http.Request) {},
 		},
 	)
-	err = RegisterRoutes(coreTesting.NewTestContext(t), muxRouter, gRouter, nil, "", routes)
+	err = RegisterRoutes(coreTesting.NewTestContext(t), gRouter, nil, "", routes)
 	require.NoError(t, err)
 
 	// Now generate the OpenAPI spec


### PR DESCRIPTION
- Updated RegisterRoutes to get mux.Router from swagger router instead of requiring it as parameter
- Updated router tests to match new function signature
- Updated go.mod dependency version for gswagger