### PR TITLE
feat: add APIInfoDefinition interface for OpenAPI metadata

### DIFF
--- a/api_info.go
+++ b/api_info.go
@@ -2,6 +2,17 @@ package httputil
 
 import "github.com/getkin/kin-openapi/openapi3"
 
+// APIInfoDefinition defines the contract for building OpenAPI info metadata
+type APIInfoDefinition interface {
+	Title(title string) APIInfoDefinition
+	Version(version string) APIInfoDefinition
+	Description(desc string) APIInfoDefinition
+	Contact(email, name string) APIInfoDefinition
+	License(name, url string) APIInfoDefinition
+	TermsOfService(terms string) APIInfoDefinition
+	toOpenAPI() *openapi3.Info
+}
+
 type apiInfo struct {
 	title       string
 	version     string
@@ -11,26 +22,26 @@ type apiInfo struct {
 	terms       string
 }
 
-func APIInfo() *apiInfo {
+func APIInfo() APIInfoDefinition {
 	return &apiInfo{}
 }
 
-func (i *apiInfo) Title(title string) *apiInfo {
+func (i *apiInfo) Title(title string) APIInfoDefinition {
 	i.title = title
 	return i
 }
 
-func (i *apiInfo) Version(version string) *apiInfo {
+func (i *apiInfo) Version(version string) APIInfoDefinition {
 	i.version = version
 	return i
 }
 
-func (i *apiInfo) Description(desc string) *apiInfo {
+func (i *apiInfo) Description(desc string) APIInfoDefinition {
 	i.description = desc
 	return i
 }
 
-func (i *apiInfo) Contact(email, name string) *apiInfo {
+func (i *apiInfo) Contact(email, name string) APIInfoDefinition {
 	i.contact = &openapi3.Contact{
 		Email: email,
 		Name:  name,
@@ -38,7 +49,7 @@ func (i *apiInfo) Contact(email, name string) *apiInfo {
 	return i
 }
 
-func (i *apiInfo) License(name, url string) *apiInfo {
+func (i *apiInfo) License(name, url string) APIInfoDefinition {
 	i.license = &openapi3.License{
 		Name: name,
 		URL:  url,
@@ -46,7 +57,7 @@ func (i *apiInfo) License(name, url string) *apiInfo {
 	return i
 }
 
-func (i *apiInfo) TermsOfService(terms string) *apiInfo {
+func (i *apiInfo) TermsOfService(terms string) APIInfoDefinition {
 	i.terms = terms
 	return i
 }

--- a/router.go
+++ b/router.go
@@ -45,7 +45,7 @@ func GetRouter(r Router) *mux.Router {
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-func NewSwaggerRouter(muxRouter *mux.Router, info *apiInfo) (Router, error) {
+func NewSwaggerRouter(muxRouter *mux.Router, info APIInfoDefinition) (Router, error) {
 	router, err := swagger.NewRouter(gs.NewRouter(muxRouter), swagger.Options{
 		JSONDocumentationPath: SwaggerJSONPath,
 		YAMLDocumentationPath: SwaggerYAMLPath,


### PR DESCRIPTION
- Introduced APIInfoDefinition interface to standardize OpenAPI info building
- Made apiInfo struct implement the new interface
- Updated NewSwaggerRouter to accept APIInfoDefinition instead of concrete type
- Maintained backward compatibility with existing usage