### PR TITLE
feat: add getter methods to APIInfo interface

### DIFF
--- a/api_info.go
+++ b/api_info.go
@@ -5,11 +5,17 @@ import "github.com/getkin/kin-openapi/openapi3"
 // APIInfoDefinition defines the contract for building OpenAPI info metadata
 type APIInfoDefinition interface {
 	Title(title string) APIInfoDefinition
+	GetTitle() string
 	Version(version string) APIInfoDefinition
+	GetVersion() string
 	Description(desc string) APIInfoDefinition
+	GetDescription() string
 	Contact(email, name string) APIInfoDefinition
+	GetContact() (email, name string)
 	License(name, url string) APIInfoDefinition
+	GetLicense() (name, url string)
 	TermsOfService(terms string) APIInfoDefinition
+	GetTermsOfService() string
 	toOpenAPI() *openapi3.Info
 }
 
@@ -60,6 +66,36 @@ func (i *apiInfo) License(name, url string) APIInfoDefinition {
 func (i *apiInfo) TermsOfService(terms string) APIInfoDefinition {
 	i.terms = terms
 	return i
+}
+
+func (i *apiInfo) GetTitle() string {
+	return i.title
+}
+
+func (i *apiInfo) GetVersion() string {
+	return i.version
+}
+
+func (i *apiInfo) GetDescription() string {
+	return i.description
+}
+
+func (i *apiInfo) GetContact() (email, name string) {
+	if i.contact == nil {
+		return "", ""
+	}
+	return i.contact.Email, i.contact.Name
+}
+
+func (i *apiInfo) GetLicense() (name, url string) {
+	if i.license == nil {
+		return "", ""
+	}
+	return i.license.Name, i.license.URL
+}
+
+func (i *apiInfo) GetTermsOfService() string {
+	return i.terms
 }
 
 func (i *apiInfo) toOpenAPI() *openapi3.Info {

--- a/api_info_test.go
+++ b/api_info_test.go
@@ -80,4 +80,39 @@ func TestAPIInfoBuilder(t *testing.T) {
 		assert.Empty(t, oasInfo.Title)
 		assert.Empty(t, oasInfo.Version)
 	})
+
+	t.Run("getter methods", func(t *testing.T) {
+		info := APIInfo().
+			Title("Test API").
+			Version("1.0.0").
+			Description("Test Description").
+			TermsOfService("https://example.com/tos").
+			Contact("support@example.com", "Support Team").
+			License("MIT", "https://opensource.org/licenses/MIT")
+
+		assert.Equal(t, "Test API", info.GetTitle())
+		assert.Equal(t, "1.0.0", info.GetVersion())
+		assert.Equal(t, "Test Description", info.GetDescription())
+		assert.Equal(t, "https://example.com/tos", info.GetTermsOfService())
+
+		email, name := info.GetContact()
+		assert.Equal(t, "support@example.com", email)
+		assert.Equal(t, "Support Team", name)
+
+		licenseName, licenseURL := info.GetLicense()
+		assert.Equal(t, "MIT", licenseName)
+		assert.Equal(t, "https://opensource.org/licenses/MIT", licenseURL)
+	})
+
+	t.Run("nil contact and license getters", func(t *testing.T) {
+		info := APIInfo().Title("Test").Version("1.0")
+
+		email, name := info.GetContact()
+		assert.Empty(t, email)
+		assert.Empty(t, name)
+
+		licenseName, licenseURL := info.GetLicense()
+		assert.Empty(t, licenseName)
+		assert.Empty(t, licenseURL)
+	})
 }


### PR DESCRIPTION
Add getter methods to APIInfoDefinition interface and apiInfo implementation:
- GetTitle()
- GetVersion()
- GetDescription()
- GetContact()
- GetLicense()
- GetTermsOfService()

Also includes corresponding test cases to verify the getter behavior, including handling of nil contact and license cases.