### PR TITLE
refactor(route): move middleware options to middleware package

### DIFF
--- a/route_builder.go
+++ b/route_builder.go
@@ -1,10 +1,7 @@
 package httputil
 
 import (
-	"github.com/gorilla/mux"
 	swagger "go.lumeweb.com/gswagger"
-	"go.lumeweb.com/portal-middleware/auth/jwt"
-	"go.lumeweb.com/portal-middleware/middleware"
 	"go.lumeweb.com/portal/core"
 	"net/http"
 )
@@ -39,24 +36,5 @@ func WithAccess(accessRole string) RouteOption {
 func WithSwagger(def swagger.Definitions) RouteOption {
 	return func(d *RouteDefinition) {
 		d.Swagger = def
-	}
-}
-
-func WithVerification(ctx core.Context) RouteOption {
-	return func(d *RouteDefinition) {
-		d.Middlewares = append(d.Middlewares, middleware.AccountVerifiedMiddleware(ctx))
-	}
-}
-
-func With2FA(ctx core.Context) RouteOption {
-	return func(d *RouteDefinition) {
-		d.Middlewares = append(d.Middlewares, middleware.AuthMiddleware(ctx, jwt.Purpose2FA))
-	}
-}
-
-// Middleware option
-func WithMiddleware(mw ...mux.MiddlewareFunc) RouteOption {
-	return func(d *RouteDefinition) {
-		d.Middlewares = append(d.Middlewares, mw...)
 	}
 }

--- a/route_builder_test.go
+++ b/route_builder_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"go.lumeweb.com/portal/core"
-	coreTesting "go.lumeweb.com/portal/core/testing"
-	"go.lumeweb.com/portal/core/testing/mocks"
 )
 
 func TestNewRoute(t *testing.T) {
@@ -45,40 +43,6 @@ func TestWithSwagger(t *testing.T) {
 	assert.Equal(t, "Test Summary", route.Swagger.Summary)
 }
 
-func TestWithVerification(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
-	ctx := coreTesting.NewTestContext(t)
-
-	// Setup mock expectations
-	mockUser := mocks.NewMockUserService(t)
-	ctx.RegisterService(core.USER_SERVICE, mockUser)
-
-	route := NewRoute("GET", "/test", handler, WithVerification(ctx))
-
-	assert.Len(t, route.Middlewares, 1)
-	mockUser.AssertExpectations(t)
-}
-
-func TestWith2FA(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
-	ctx := mocks.NewMockContext(t)
-
-	route := NewRoute("GET", "/test", handler, With2FA(ctx))
-
-	assert.Len(t, route.Middlewares, 1)
-}
-
-func TestWithMiddleware(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
-	mw := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	}
-
-	route := NewRoute("GET", "/test", handler, WithMiddleware(mw))
-
-	assert.Len(t, route.Middlewares, 1)
-}
-
 func TestRouteExecution(t *testing.T) {
 	called := false
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -98,29 +62,4 @@ func TestRouteExecution(t *testing.T) {
 
 	assert.True(t, called)
 	assert.Equal(t, http.StatusOK, rr.Code)
-}
-
-func TestMultipleOptions(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
-	mw := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	}
-	ctx := coreTesting.NewTestContext(t)
-
-	// Setup mock expectations
-	mockUser := mocks.NewMockUserService(t)
-	ctx.RegisterService(core.USER_SERVICE, mockUser)
-
-	route := NewRoute(
-		"GET",
-		"/test",
-		handler,
-		WithAccess(core.ACCESS_ADMIN_ROLE),
-		WithVerification(ctx),
-		WithMiddleware(mw),
-	)
-
-	assert.Equal(t, core.ACCESS_ADMIN_ROLE, route.Access)
-	assert.Len(t, route.Middlewares, 2)
-	mockUser.AssertExpectations(t)
 }


### PR DESCRIPTION
- Remove WithVerification, With2FA, and WithMiddleware route options from route_builder.go
- Remove associated test cases from route_builder_test.go
- These middleware-related utilities are being moved to the dedicated middleware package
- Part of ongoing effort to improve code organization and separation of concerns