### PR TITLE
refactor(http)!: improve JSON encoding with error handling and test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.11.0
+	go.lumeweb.com/gswagger v0.16.1
 )
 
 require (

--- a/http.go
+++ b/http.go
@@ -13,16 +13,14 @@ import (
 // Encode writes a JSON response to the client with consistent formatting:
 // - Empty slices/maps render as []/{} instead of null
 // - Uses indented JSON for human readability
-func (r RequestContext) Encode(v any) {
+func (r RequestContext) Encode(v any) error {
 	// encode nil slices as [] and nil maps as {} (instead of null)
 	if val := reflect.ValueOf(v); val.Kind() == reflect.Slice && val.Len() == 0 {
-		_ = r.JSON(http.StatusOK, []any{})
-		return
+		return r.JSON(http.StatusOK, []any{})
 	} else if val.Kind() == reflect.Map && val.Len() == 0 {
-		_ = r.JSON(http.StatusOK, map[string]any{})
-		return
+		return r.JSON(http.StatusOK, map[string]any{})
 	}
-	_ = r.JSONPretty(http.StatusOK, v, "\t")
+	return r.JSONPretty(http.StatusOK, v, "\t")
 }
 
 // Decode reads and parses the request body as JSON into the provided value.

--- a/http_test.go
+++ b/http_test.go
@@ -15,34 +15,56 @@ import (
 
 func TestEncode(t *testing.T) {
 	testCases := []struct {
-		name     string
-		input    any
-		expected string
+		name        string
+		input       any
+		expected    string
+		expectError bool
 	}{
 		{
-			name:     "Nil Slice",
-			input:    []int(nil),
-			expected: "[]\n",
+			name:        "Nil Slice",
+			input:       []int(nil),
+			expected:    "[]\n",
+			expectError: false,
 		},
 		{
-			name:     "Empty Slice",
-			input:    []int{},
-			expected: "[]\n",
+			name:        "Empty Slice",
+			input:       []int{},
+			expected:    "[]\n",
+			expectError: false,
 		},
 		{
-			name:     "Nil Map",
-			input:    map[string]int(nil),
-			expected: "{}\n",
+			name:        "Nil Map",
+			input:       map[string]int(nil),
+			expected:    "{}\n",
+			expectError: false,
 		},
 		{
-			name:     "Empty Map",
-			input:    map[string]int{},
-			expected: "{}\n",
+			name:        "Empty Map",
+			input:       map[string]int{},
+			expected:    "{}\n",
+			expectError: false,
 		},
 		{
-			name:     "Struct",
-			input:    struct{ Name string }{Name: "test"},
-			expected: "{\n\t\"Name\": \"test\"\n}\n",
+			name:        "Struct",
+			input:       struct{ Name string }{Name: "test"},
+			expected:    "{\n\t\"Name\": \"test\"\n}\n",
+			expectError: false,
+		},
+		{
+			name:        "Channel Type",
+			input:       make(chan int),
+			expectError: true,
+		},
+		{
+			name:        "Struct With Unexported Field",
+			input:       struct{ name string }{name: "test"}, // lowercase field
+			expected:    "{}\n",
+			expectError: false,
+		},
+		{
+			name:        "Function Type",
+			input:       func() {},
+			expectError: true,
 		},
 	}
 
@@ -53,13 +75,22 @@ func TestEncode(t *testing.T) {
 			e := echo.New()
 			r := Context(e.NewContext(req, w))
 
-			r.Encode(tc.input)
+			err := r.Encode(tc.input)
 
-			if w.Body.String() != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, w.Body.String())
-			}
-			if w.Header().Get("Content-Type") != "application/json" {
-				t.Errorf("expected Content-Type to be application/json, got %q", w.Header().Get("Content-Type"))
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if w.Body.String() != tc.expected {
+					t.Errorf("expected %q, got %q", tc.expected, w.Body.String())
+				}
+				if w.Header().Get("Content-Type") != "application/json" {
+					t.Errorf("expected Content-Type to be application/json, got %q", w.Header().Get("Content-Type"))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Modified Encode() method to return errors instead of silently ignoring them
- Added comprehensive test cases including:
  - Error scenarios (channel and function types)
  - Edge cases (unexported struct fields)
  - Proper content-type verification
- Ensured consistent JSON formatting for empty slices/maps
- Wpdate go.lumeweb.com/gswagger to v0.16.1