### PR TITLE
refactor: improve request body handling and test organization

### DIFF
--- a/dto_test.go
+++ b/dto_test.go
@@ -267,7 +267,7 @@ func (d *simpleDTO) ToModel() (simpleModel, error) {
 	return simpleModel{Name: d.Name}, nil
 }
 
-func TestDecodeAndValidateRequest_WithValidator(t *testing.T) {
+func TestDecodeAndValidateRequest_WithValidatorAndGetBody(t *testing.T) {
 	body := []byte(`{"field": "valid"}`)
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -309,12 +309,103 @@ func TestDecodeAndValidateRequest_WithValidator(t *testing.T) {
 	}
 }
 
-func TestDecodeAndValidateRequest_WithValidatorError(t *testing.T) {
+func TestDecodeAndValidateRequest_WithValidatorNoGetBody(t *testing.T) {
+	body := []byte(`{"field": "valid"}`)
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	// Create mock validator
+	validator := mocks.NewMockDTOValidator(t)
+	schema := z.Struct(z.Schema{
+		"Field": z.String().Min(3).Required(), // Match struct field name
+	})
+	validator.EXPECT().Schema().Return(schema)
+
+	// Create mock DTO that implements both DTORequest and DTOValidator
+	dto := &struct {
+		*mocks.MockDTORequest[*struct{ Field string }]
+		*mocks.MockDTOValidator
+		Field string `json:"field"`
+	}{
+		MockDTORequest:   mocks.NewMockDTORequest[*struct{ Field string }](t),
+		MockDTOValidator: validator,
+	}
+
+	// Set up expectations
+	model := &struct{ Field string }{Field: "valid"}
+	dto.MockDTORequest.EXPECT().ToModel().Return(model, nil).Maybe()
+	dto.MockDTOValidator.EXPECT().Schema().Return(schema)
+
+	result, ok := DecodeAndValidateRequest(r, dto)
+	if !ok {
+		t.Fatal("Unexpected validation failure")
+	}
+	if result.Field != "valid" {
+		t.Errorf("Expected model field 'valid', got %q", result.Field)
+	}
+}
+
+func TestDecodeAndValidateRequest_WithValidatorErrorAndGetBody(t *testing.T) {
 	body := []byte(`{"field": "iv"}`)
 	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(body)), nil
 	}
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	validator := mocks.NewMockDTOValidator(t)
+	schema := z.Struct(z.Schema{
+		"field": z.String().Min(3).Required(),
+	})
+	validator.EXPECT().Schema().Return(schema)
+
+	// Create mock DTO that implements both interfaces
+	dto := &struct {
+		*mocks.MockDTORequest[*struct{ Field string }]
+		*mocks.MockDTOValidator
+		Field string `json:"field"`
+	}{
+		MockDTORequest:   mocks.NewMockDTORequest[*struct{ Field string }](t),
+		MockDTOValidator: validator,
+	}
+
+	_, ok := DecodeAndValidateRequest(r, dto)
+	if ok {
+		t.Fatal("Expected validation failure, got success")
+	}
+
+	// Verify response status and error format
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnprocessableEntity, w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if resp["error"] == nil {
+		t.Error("Expected error message in response")
+	}
+
+	fields, ok := resp["fields"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected 'fields' to be a map in the response")
+	}
+	if len(fields) == 0 {
+		t.Error("Expected field errors in response")
+	}
+}
+
+func TestDecodeAndValidateRequest_WithValidatorErrorNoGetBody(t *testing.T) {
+	body := []byte(`{"field": "iv"}`)
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	e := echo.New()

--- a/http.go
+++ b/http.go
@@ -26,9 +26,15 @@ func (r RequestContext) Encode(v any) error {
 // Decode reads and parses the request body as JSON into the provided value.
 // Returns an error wrapped with type information if decoding fails
 func (r RequestContext) Decode(v any) error {
-	if err := r.Bind(v); err != nil {
+	_, err := r.readRequestBody()
+	if err != nil {
+		return err
+	}
+
+	if err = r.Bind(v); err != nil {
 		return fmt.Errorf("couldn't decode request type (%T): %w", v, err)
 	}
+
 	return nil
 }
 

--- a/validation.go
+++ b/validation.go
@@ -86,36 +86,13 @@ func (r RequestContext) Validate(validator DTOValidator) error {
 		}
 	}
 
-	// Handle body re-reading
-	var body bytes.Buffer
-	if r.Request().GetBody == nil {
-		// Read and restore body when GetBody isn't available
-		bodyContent, err := io.ReadAll(r.Request().Body)
-		if err != nil {
-			return fmt.Errorf("error reading request body: %w", err)
-		}
-		r.Request().Body = io.NopCloser(bytes.NewReader(bodyContent))
-		body.Write(bodyContent)
-	} else {
-		// Use GetBody to get a fresh copy
-		bodyCopy, err := r.Request().GetBody()
-		if err != nil {
-			return fmt.Errorf("error getting request body: %w", err)
-		}
-		defer func(bodyCopy io.ReadCloser) {
-			err := bodyCopy.Close()
-			if err != nil {
-				r.Context.Logger().Error(err)
-			}
-		}(bodyCopy)
-		_, err = body.ReadFrom(bodyCopy)
-		if err != nil {
-			return fmt.Errorf("error reading request body: %w", err)
-		}
+	body, err := r.readRequestBody()
+	if err != nil {
+		return fmt.Errorf("error reading request body: %w", err)
 	}
 
 	// Parse returns []ZogIssue and handles validation using the request body
-	issues := schema.Parse(zjson.Decode(&body), validator)
+	issues := schema.Parse(zjson.Decode(body), validator)
 	if len(issues) > 0 {
 		sanitized := z.Issues.SanitizeMap(issues)
 
@@ -155,28 +132,12 @@ func (r RequestContext) ValidateRequest(entity DTOValidator) (map[string]string,
 		}
 	}
 
-	// Handle body re-reading
-	var body bytes.Buffer
-	if r.Request().GetBody == nil {
-		bodyContent, err := io.ReadAll(r.Request().Body)
-		if err != nil {
-			return nil, fmt.Errorf("error reading request body: %w", err)
-		}
-		r.Request().Body = io.NopCloser(bytes.NewReader(bodyContent))
-		body.Write(bodyContent)
-	} else {
-		bodyCopy, err := r.Request().GetBody()
-		if err != nil {
-			return nil, fmt.Errorf("error getting request body: %w", err)
-		}
-		defer bodyCopy.Close()
-		_, err = body.ReadFrom(bodyCopy)
-		if err != nil {
-			return nil, fmt.Errorf("error reading request body: %w", err)
-		}
+	body, err := r.readRequestBody()
+	if err != nil {
+		return nil, fmt.Errorf("error reading request body: %w", err)
 	}
 
-	errs := schema.Parse(zjson.Decode(&body), entity)
+	errs := schema.Parse(zjson.Decode(body), entity)
 	if errs != nil {
 		sanitized := z.Issues.SanitizeMap(errs)
 		validationErrors := make(map[string]string)
@@ -190,8 +151,70 @@ func (r RequestContext) ValidateRequest(entity DTOValidator) (map[string]string,
 	return nil, nil
 }
 
+func (r RequestContext) readRequestBody() (*bytes.Buffer, error) {
+	var body bytes.Buffer
+
+	if r.Request().GetBody == nil {
+		// Read and cache the original body content
+		bodyContent, err := io.ReadAll(r.Request().Body)
+		if err != nil {
+			return nil, err
+		}
+
+		// Replace body with seekable version
+		r.Request().Body = newSeekableBuffer(bodyContent)
+
+		// Set GetBody factory
+		r.Request().GetBody = getBodyFactory(bodyContent)
+
+		// Store content in our buffer
+		body.Write(bodyContent)
+	} else {
+		// Use existing GetBody functionality
+		bodyCopy, err := r.Request().GetBody()
+		if err != nil {
+			return nil, err
+		}
+		defer func(bodyCopy io.ReadCloser) {
+			err := bodyCopy.Close()
+			if err != nil {
+				r.Context.Logger().Error(err)
+			}
+		}(bodyCopy)
+
+		if _, err := body.ReadFrom(bodyCopy); err != nil {
+			return nil, err
+		}
+	}
+
+	return &body, nil
+}
+
 // ToJSON is a generic helper function that marshals data to JSON.
 // Provides consistent JSON encoding across the package.
 func ToJSON[T any](data T) ([]byte, error) {
 	return json.Marshal(data)
+}
+
+// newSeekableBuffer creates a new seekable ReadCloser from the given content
+func newSeekableBuffer(content []byte) io.ReadCloser {
+	return &seekableBuffer{
+		Reader: bytes.NewReader(content),
+	}
+}
+
+// seekableBuffer implements io.ReadCloser with seeking support
+type seekableBuffer struct {
+	*bytes.Reader
+}
+
+func (s *seekableBuffer) Close() error {
+	return nil
+}
+
+// getBodyFactory creates a GetBody function for the given content
+func getBodyFactory(content []byte) func() (io.ReadCloser, error) {
+	return func() (io.ReadCloser, error) {
+		return newSeekableBuffer(content), nil
+	}
 }


### PR DESCRIPTION
- Extracted request body reading logic into dedicated `readRequestBody()` method
  - Handles both cases with and without GetBody function
  - Implements seekable buffer for request body reuse
- Updated `Decode()` method to use new body reading approach
- Reorganized test cases in dto_test.go to clearly separate:
  - Tests with GetBody functionality
  - Tests without GetBody functionality
  - Error scenarios for both cases
- Added helper functions for seekable buffer implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal handling of HTTP request body reading and validation for more consistent and reliable behavior.
- **Tests**
	- Expanded test coverage to ensure validation works correctly whether or not the HTTP request supports re-reading its body.
- **Bug Fixes**
	- Enhanced error reporting and response status codes during validation failures when the request body cannot be re-read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->