### PR TITLE
feat(http): add file upload handling with size validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,43 +6,27 @@ toolchain go1.23.7
 
 require (
 	github.com/Oudwins/zog v0.18.4
-	github.com/getkin/kin-openapi v0.132.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/gswagger v0.16.1
 )
 
 require (
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
-	github.com/invopop/jsonschema v0.12.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
-	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
-	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
-	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/http.go
+++ b/http.go
@@ -1,14 +1,107 @@
 package httputil
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// FileUploadResult contains the uploaded file and its metadata
+type FileUploadResult struct {
+	File     io.ReadSeekCloser
+	Size     uint64
+	Filename string
+}
+
+// PrepareFileUpload handles both multipart form uploads and raw body uploads.
+// It supports:
+// - Multipart form file uploads (with Content-Type: multipart/form-data)
+// - Raw binary uploads (with any other Content-Type)
+// - Automatic handling of seekable vs non-seekable sources
+// - Size validation against maxUploadSize
+func (r RequestContext) PrepareFileUpload(maxUploadSize int64) (*FileUploadResult, error) {
+	req := r.Request()
+	contentType := req.Header.Get("Content-Type")
+
+	// Handle multipart form data uploads
+	if strings.HasPrefix(contentType, "multipart/form-data") {
+		// Check Content-Length header first to prevent processing large files
+		if req.ContentLength > maxUploadSize {
+			return nil, fmt.Errorf("file size exceeds maximum allowed size of %d bytes", maxUploadSize)
+		}
+
+		if err := req.ParseMultipartForm(maxUploadSize); err != nil {
+			return nil, fmt.Errorf("failed to parse multipart form: %w", err)
+		}
+
+		multipartFile, multipartHeader, err := req.FormFile("file")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get file from form: %w", err)
+		}
+
+		// Check if the multipart file supports seeking
+		if seeker, ok := multipartFile.(io.Seeker); ok {
+			// More reliable seek test - seek to start and back to original position
+			if _, err := seeker.Seek(0, io.SeekStart); err == nil {
+				// Success - we can use the original file with seeking support
+				defer func() {
+					if err != nil {
+						multipartFile.Close()
+					}
+				}()
+				return &FileUploadResult{
+					File:     multipartFile,
+					Size:     uint64(multipartHeader.Size),
+					Filename: multipartHeader.Filename,
+				}, nil
+			}
+		}
+
+		// If seeking isn't supported or failed, fallback to buffering
+		defer multipartFile.Close()
+		data, err := io.ReadAll(multipartFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read multipart file: %w", err)
+		}
+
+		return &FileUploadResult{
+			File:     readSeekNopCloser{bytes.NewReader(data)},
+			Size:     uint64(len(data)),
+			Filename: multipartHeader.Filename,
+		}, nil
+	}
+
+	// Handle raw body uploads with size-limited reader
+	limitedReader := &io.LimitedReader{R: req.Body, N: maxUploadSize + 1}
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if limitedReader.N <= 0 {
+		return nil, fmt.Errorf("file size exceeds maximum allowed size of %d bytes", maxUploadSize)
+	}
+
+	return &FileUploadResult{
+		File: readSeekNopCloser{bytes.NewReader(data)},
+		Size: uint64(len(data)),
+	}, nil
+}
+
+// readSeekNopCloser implements io.ReadSeekCloser for bytes.Reader
+type readSeekNopCloser struct {
+	*bytes.Reader
+}
+
+func (rsnc readSeekNopCloser) Close() error {
+	return nil
+}
 
 // Encode writes a JSON response to the client with consistent formatting:
 // - Empty slices/maps render as []/{} instead of null

--- a/http_test.go
+++ b/http_test.go
@@ -2,9 +2,13 @@ package httputil
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -368,6 +372,177 @@ type StringLoader string
 func (s *StringLoader) LoadString(value string) error {
 	*s = StringLoader("loaded: " + value)
 	return nil
+}
+
+func TestPrepareFileUpload_Multipart(t *testing.T) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = part.Write([]byte("test file content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	req := httptest.NewRequest("POST", "/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	result, err := r.PrepareFileUpload(1024 * 1024) // 1MB limit
+	if err != nil {
+		t.Fatalf("PrepareFileUpload failed: %v", err)
+	}
+	defer result.File.Close()
+
+	if result.Filename != "test.txt" {
+		t.Errorf("Expected filename 'test.txt', got '%s'", result.Filename)
+	}
+	if result.Size != 17 {
+		t.Errorf("Expected size 17, got %d", result.Size)
+	}
+
+	content, err := io.ReadAll(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "test file content" {
+		t.Errorf("Expected content 'test file content', got '%s'", string(content))
+	}
+}
+
+func TestPrepareFileUpload_RawBody(t *testing.T) {
+	content := []byte("raw file content")
+	req := httptest.NewRequest("POST", "/upload", bytes.NewReader(content))
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	result, err := r.PrepareFileUpload(1024 * 1024) // 1MB limit
+	if err != nil {
+		t.Fatalf("PrepareFileUpload failed: %v", err)
+	}
+	defer result.File.Close()
+
+	if result.Size != uint64(len(content)) {
+		t.Errorf("Expected size %d, got %d", len(content), result.Size)
+	}
+
+	readContent, err := io.ReadAll(result.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(readContent, content) {
+		t.Errorf("Expected content %q, got %q", content, readContent)
+	}
+}
+
+func TestPrepareFileUpload_SizeLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentSize int
+		limit       int64
+		expectError bool
+	}{
+		{
+			name:        "Raw body at limit",
+			contentSize: 10 << 20, // 10MB
+			limit:       10 << 20, // 10MB limit
+			expectError: false,
+		},
+		{
+			name:        "Raw body over limit",
+			contentSize: 11 << 20, // 11MB
+			limit:       10 << 20, // 10MB limit
+			expectError: true,
+		},
+		{
+			name:        "Multipart at limit",
+			contentSize: 10 << 20, // 10MB
+			limit:       0,        // 0 + 10MB buffer
+			expectError: false,
+		},
+		{
+			name:        "Multipart over limit",
+			contentSize: 11 << 20, // 11MB
+			limit:       1,        // 0 + 10MB buffer
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if strings.Contains(tt.name, "Multipart") {
+				// Test multipart form
+				body := &bytes.Buffer{}
+				writer := multipart.NewWriter(body)
+				part, err := writer.CreateFormFile("file", "test.txt")
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Fill with random data instead of null bytes
+				data := make([]byte, tt.contentSize)
+				_, err = rand.Read(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = part.Write(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = writer.Close()
+				if err != nil {
+					require.NoError(t, err)
+				}
+
+				req := httptest.NewRequest("POST", "/upload", body)
+				req.Header.Set("Content-Type", writer.FormDataContentType())
+				w := httptest.NewRecorder()
+				e := echo.New()
+				r := Context(e.NewContext(req, w))
+
+				_, err = r.PrepareFileUpload(tt.limit)
+				if tt.expectError {
+					if err == nil {
+						t.Error("Expected error for exceeding size limit")
+					}
+					if !strings.Contains(err.Error(), "exceeds maximum allowed size") {
+						t.Errorf("Expected size limit error, got: %v", err)
+					}
+				} else if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			} else {
+				// Test raw body
+				// Fill with random data instead of null bytes
+				data := make([]byte, tt.contentSize)
+				_, err := rand.Read(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req := httptest.NewRequest("POST", "/upload", bytes.NewReader(data))
+				w := httptest.NewRecorder()
+				e := echo.New()
+				r := Context(e.NewContext(req, w))
+
+				_, err = r.PrepareFileUpload(tt.limit)
+				if tt.expectError {
+					if err == nil {
+						t.Error("Expected error for exceeding size limit")
+					}
+					if !strings.Contains(err.Error(), "exceeds maximum allowed size") {
+						t.Errorf("Expected size limit error, got: %v", err)
+					}
+				} else if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }
 
 func TestDecodeForm_CustomTypes(t *testing.T) {


### PR DESCRIPTION
* Introduces FileUploadResult struct to hold uploaded file metadata
* Implements PrepareFileUpload method to handle both multipart and raw file uploads
* Supports seekable and non-seekable sources
* Validates against maximum upload size
* Adds comprehensive tests for multipart, raw body, and size limit scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling file uploads from HTTP requests, including both multipart form and raw binary uploads, with size limit enforcement.

* **Tests**
  * Introduced tests to verify correct handling of multipart file uploads, raw body uploads, and enforcement of file size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->