### PR TITLE
refactor: instead of fetching the body, use the validator as-is and assume its already been decoded via r.Decode

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -61,7 +61,7 @@ func IsValidationError(err error) bool {
 	return errors.As(err, &verr)
 }
 
-// Validate applies schema validation to the request body using zog schemas.
+// Validate applies schema validation against a pre-populated DTOValidator.
 // Returns:
 // - nil on successful validation
 // - ValidationError with field-specific errors on failure
@@ -86,13 +86,8 @@ func (r RequestContext) Validate(validator DTOValidator) error {
 		}
 	}
 
-	body, err := r.readRequestBody()
-	if err != nil {
-		return fmt.Errorf("error reading request body: %w", err)
-	}
-
-	// Parse returns []ZogIssue and handles validation using the request body
-	issues := schema.Parse(zjson.Decode(body), validator)
+	// Validate returns []ZogIssue and handles validation using the request body
+	issues := schema.Validate(validator)
 	if len(issues) > 0 {
 		sanitized := z.Issues.SanitizeMap(issues)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the request validation process for better efficiency and maintainability. No changes to user-facing features or interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->