### PR TITLE
refactor: update validation error handling for zog v0.22

### DIFF
--- a/git-town.toml
+++ b/git-town.toml
@@ -1,0 +1,20 @@
+# See https://www.git-town.com/configuration-file for details
+
+[branches]
+main = "develop"
+
+[create]
+share-new-branches = "no"
+
+[hosting]
+forge-type = "github"
+github-connector = "gh"
+
+[ship]
+delete-tracking-branch = true
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"
+push-hook = true
+upstream = true

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,18 @@
 module go.lumeweb.com/httputil
 
-go 1.23.1
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.3
 
 require (
-	github.com/Oudwins/zog v0.18.4
-	github.com/labstack/echo/v4 v4.13.4
-	github.com/stretchr/testify v1.10.0
+	github.com/Oudwins/zog v0.22.0
+	github.com/labstack/echo/v4 v4.14.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/docker/go-units v0.5.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -21,11 +22,11 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/text v0.32.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/http_test.go
+++ b/http_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"github.com/docker/go-units"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -393,7 +394,7 @@ func TestPrepareFileUpload_Multipart(t *testing.T) {
 	e := echo.New()
 	r := Context(e.NewContext(req, w))
 
-	result, err := r.PrepareFileUpload(1024 * 1024) // 1MB limit
+	result, err := r.PrepareFileUpload(units.MB) // 1MB limit
 	if err != nil {
 		t.Fatalf("PrepareFileUpload failed: %v", err)
 	}
@@ -422,7 +423,7 @@ func TestPrepareFileUpload_RawBody(t *testing.T) {
 	e := echo.New()
 	r := Context(e.NewContext(req, w))
 
-	result, err := r.PrepareFileUpload(1024 * 1024) // 1MB limit
+	result, err := r.PrepareFileUpload(units.MB) // 1MB limit
 	if err != nil {
 		t.Fatalf("PrepareFileUpload failed: %v", err)
 	}
@@ -450,26 +451,26 @@ func TestPrepareFileUpload_SizeLimit(t *testing.T) {
 	}{
 		{
 			name:        "Raw body at limit",
-			contentSize: 10 << 20, // 10MB
-			limit:       10 << 20, // 10MB limit
+			contentSize: 10 * units.MB,
+			limit:       10 * units.MB,
 			expectError: false,
 		},
 		{
 			name:        "Raw body over limit",
-			contentSize: 11 << 20, // 11MB
-			limit:       10 << 20, // 10MB limit
+			contentSize: 11 * units.MB,
+			limit:       10 * units.MB,
 			expectError: true,
 		},
 		{
 			name:        "Multipart at limit",
-			contentSize: 10 << 20, // 10MB
-			limit:       0,        // 0 + 10MB buffer
+			contentSize: (10 * units.MB) - 500,
+			limit:       10 * units.MB,
 			expectError: false,
 		},
 		{
 			name:        "Multipart over limit",
-			contentSize: 11 << 20, // 11MB
-			limit:       1,        // 0 + 10MB buffer
+			contentSize: 11 * units.MB,
+			limit:       10 * units.MB,
 			expectError: true,
 		},
 	}

--- a/validation.go
+++ b/validation.go
@@ -89,14 +89,13 @@ func (r RequestContext) Validate(validator DTOValidator) error {
 	// Validate returns []ZogIssue and handles validation using the request body
 	issues := schema.Validate(validator)
 	if len(issues) > 0 {
-		sanitized := z.Issues.SanitizeMap(issues)
-
-		fieldErrors := make(map[string]string, len(sanitized))
+		fieldErrors := make(map[string]string, len(issues))
 		var errs []error
 
-		for path, messages := range sanitized {
-			if len(messages) > 0 {
-				msg := fmt.Sprintf("%s: %s", path, messages[0])
+		for _, issue := range issues {
+			path := issue.PathString()
+			if len(path) > 0 {
+				msg := fmt.Sprintf("%s: %s", path, issue.Message)
 				fieldErrors[path] = msg
 				errs = append(errs, errors.New(msg))
 			}
@@ -134,11 +133,11 @@ func (r RequestContext) ValidateRequest(entity DTOValidator) (map[string]string,
 
 	errs := schema.Parse(zjson.Decode(body), entity)
 	if errs != nil {
-		sanitized := z.Issues.SanitizeMap(errs)
 		validationErrors := make(map[string]string)
-		for path, messages := range sanitized {
-			if len(messages) > 0 {
-				validationErrors[path] = messages[0]
+		for _, issue := range errs {
+			path := issue.PathString()
+			if len(path) > 0 {
+				validationErrors[path] = issue.Message
 			}
 		}
 		return validationErrors, nil

--- a/validation.go
+++ b/validation.go
@@ -94,11 +94,17 @@ func (r RequestContext) Validate(validator DTOValidator) error {
 
 		for _, issue := range issues {
 			path := issue.PathString()
-			if len(path) > 0 {
-				msg := fmt.Sprintf("%s: %s", path, issue.Message)
-				fieldErrors[path] = msg
-				errs = append(errs, errors.New(msg))
+			if len(issue.Message) == 0 {
+				continue
 			}
+			var msg string
+			if len(path) > 0 {
+				msg = fmt.Sprintf("%s: %s", path, issue.Message)
+			} else {
+				msg = issue.Message
+			}
+			fieldErrors[path] = msg
+			errs = append(errs, errors.New(msg))
 		}
 
 		return &ValidationError{
@@ -136,9 +142,10 @@ func (r RequestContext) ValidateRequest(entity DTOValidator) (map[string]string,
 		validationErrors := make(map[string]string)
 		for _, issue := range errs {
 			path := issue.PathString()
-			if len(path) > 0 {
-				validationErrors[path] = issue.Message
+			if len(issue.Message) == 0 {
+				continue
 			}
+			validationErrors[path] = issue.Message
 		}
 		return validationErrors, nil
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -22,6 +22,7 @@ func TestValidate_ValidRequest(t *testing.T) {
 	r := Context(e.NewContext(req, w))
 
 	validator := mocks.NewMockDTOValidator(t)
+	validator.Field = "valid_value"
 	schema := z.Struct(z.Schema{
 		"Field": z.String().Min(3).Required(), // Match struct field name
 	})
@@ -44,8 +45,9 @@ func TestValidate_InvalidRequest(t *testing.T) {
 	r := Context(e.NewContext(req, w))
 
 	validator := mocks.NewMockDTOValidator(t)
+	validator.Field = "iv"
 	schema := z.Struct(z.Schema{
-		"field": z.String().Min(3).Required(),
+		"Field": z.String().Min(3).Required(),
 	})
 
 	validator.EXPECT().Schema().Return(schema)
@@ -61,8 +63,8 @@ func TestValidate_InvalidRequest(t *testing.T) {
 	}
 
 	expected := "string must contain at least 3 character(s)"
-	if !strings.Contains(vErr.Fields()["field"], expected) {
-		t.Errorf("Expected error to contain %q, got %q", expected, vErr.Fields()["field"])
+	if !strings.Contains(vErr.Fields()["Field"], expected) {
+		t.Errorf("Expected error to contain %q, got %q", expected, vErr.Fields()["Field"])
 	}
 }
 
@@ -226,8 +228,9 @@ func TestValidate_EmptyField(t *testing.T) {
 
 	// Create and setup validator mock
 	validator := mocks.NewMockDTOValidator(t)
+	validator.Field = "a"
 	schema := z.Struct(z.Schema{
-		"field": z.String().Min(3).Required(),
+		"Field": z.String().Min(3).Required(),
 	})
 	validator.EXPECT().Schema().Return(schema)
 
@@ -243,8 +246,8 @@ func TestValidate_EmptyField(t *testing.T) {
 	}
 
 	expected := "string must contain at least 3 character(s)"
-	if !strings.Contains(vErr.Fields()["field"], expected) {
-		t.Errorf("Error message should contain %q, got %q", expected, vErr.Fields()["field"])
+	if !strings.Contains(vErr.Fields()["Field"], expected) {
+		t.Errorf("Error message should contain %q, got %q", expected, vErr.Fields()["Field"])
 	}
 }
 
@@ -290,9 +293,11 @@ func TestValidationError_MultipleFields(t *testing.T) {
 	r := Context(e.NewContext(req, w))
 
 	validator := mocks.NewMockDTOValidator(t)
+	validator.Field1 = "a"
+	validator.Field2 = ""
 	schema := z.Struct(z.Schema{
-		"field1": z.String().Min(3), // Match struct field name case
-		"field2": z.String().Required(),
+		"Field1": z.String().Min(3), // Match struct field name case
+		"Field2": z.String().Required(),
 	})
 	validator.EXPECT().Schema().Return(schema)
 
@@ -307,8 +312,8 @@ func TestValidationError_MultipleFields(t *testing.T) {
 	}
 
 	expectedErrors := map[string]string{
-		"field1": "string must contain at least 3 character(s)",
-		"field2": "field2: is required",
+		"Field1": "string must contain at least 3 character(s)",
+		"Field2": "is required",
 	}
 
 	for field, expected := range expectedErrors {

--- a/validation_test.go
+++ b/validation_test.go
@@ -327,3 +327,86 @@ func TestValidationError_MultipleFields(t *testing.T) {
 		}
 	}
 }
+
+func TestValidate_RootLevelError(t *testing.T) {
+	body := []byte(`{}`)
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	validator := mocks.NewMockDTOValidator(t)
+	validator.Field = ""
+	schema := z.Struct(z.Schema{
+		"Field": z.String().Required(),
+	})
+	validator.EXPECT().Schema().Return(schema)
+
+	err := r.Validate(validator)
+	if err == nil {
+		t.Fatal("Expected validation error")
+	}
+
+	vErr, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("Expected ValidationError, got %T", err)
+	}
+
+	// Root-level errors should be captured with empty path as key
+	if len(vErr.Fields()) == 0 {
+		t.Fatal("Expected at least one validation error, got none")
+	}
+
+	// Check that the error message is present
+	found := false
+	for _, msg := range vErr.Fields() {
+		if strings.Contains(msg, "is required") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected error message to contain 'is required', got %v", vErr.Fields())
+	}
+}
+
+func TestValidateRequest_RootLevelError(t *testing.T) {
+	body := []byte(`{}`)
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	e := echo.New()
+	r := Context(e.NewContext(req, w))
+
+	validator := mocks.NewMockDTOValidator(t)
+	schema := z.Struct(z.Schema{
+		"field": z.String().Required(),
+	})
+	validator.EXPECT().Schema().Return(schema)
+
+	validationErrors, err := r.ValidateRequest(validator)
+	if err != nil {
+		t.Fatalf("ValidateRequest returned unexpected error: %v", err)
+	}
+	if validationErrors == nil {
+		t.Fatal("Expected validation errors, got nil")
+	}
+
+	// Root-level errors should be captured
+	if len(validationErrors) == 0 {
+		t.Fatal("Expected at least one validation error, got none")
+	}
+
+	// Check that the error message is present
+	found := false
+	for _, msg := range validationErrors {
+		if strings.Contains(msg, "is required") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected error message to contain 'is required', got %v", validationErrors)
+	}
+}


### PR DESCRIPTION
- Remove deprecated `z.Issues.SanitizeMap()` usage
- Use `issue.PathString()` and `issue.Message` directly
- Fix field name casing in validation tests to match struct fields
- Upgrade Go to 1.24.0 and toolchain to go1.24.3
- Update zog to v0.22.0, echo/v4 to v4.14.0, and testify to v1.11.1
- Add docker/go-units for size unit handling in tests


---

<!-- kody-pr-summary:start -->
This pull request primarily refactors the validation error handling to align with updates in `zog` v0.22.

Key changes include:
*   **Updated Validation Error Processing:** The system now directly processes `zog.Issue` objects to extract validation error paths and messages, removing an intermediate sanitization step and simplifying the error handling logic in `RequestContext.Validate` and `RequestContext.ValidateRequest`.
*   **Adjusted Validation Tests:** Validation tests have been updated to reflect the new error handling mechanism, including correcting schema field names to match Go's exported struct field conventions and updating expected error messages and formats. Mock validators are also now explicitly initialized with field values.
*   **Improved File Size Readability in Tests:** File upload size limits in `http_test.go` now use the `github.com/docker/go-units` package for better readability and maintainability.
*   **Added Git-Town Configuration:** A `git-town.toml` file has been added to configure Git-Town, standardizing repository workflow settings such as branch naming, hosting type, and sync strategies.
<!-- kody-pr-summary:end -->